### PR TITLE
WHITE009/#64-Referral/Referring-Organization/Client-Workflow

### DIFF
--- a/A New Hope/Models/ClientProfile.cs
+++ b/A New Hope/Models/ClientProfile.cs
@@ -56,15 +56,6 @@ namespace A_New_Hope.Models
         public decimal? EarnedIncomeMonthly { get; set; }
 
         /// <summary>
-        /// Optional postal/zip code for client.
-        /// Accepts 5-digit ZIP, ZIP+4 (US), or alphanumeric for non-US postal codes.
-        /// </summary>
-        [MaxLength(20)]
-        [RegularExpression(@"^\d{5}(-\d{4})?$",
-            ErrorMessage = "Enter a valid US ZIP code.")]
-        public string? PostalCode { get; set; }
-
-        /// <summary>
         /// Indicates whether the client is currently unhoused.
         /// Defaults to false; make nullable only if you need an "unknown" state.
         /// </summary>

--- a/A New Hope/Models/ReferringOrganization.cs
+++ b/A New Hope/Models/ReferringOrganization.cs
@@ -122,7 +122,6 @@ namespace A_New_Hope.Models
         /// Optional free-form notes about the organization.
         /// Left uncapped to allow longer descriptions if needed.
         /// </summary>
-        [StringLength(2000, ErrorMessage = "Notes cannot exceed 2000 characters.")]
         public string? Notes { get; set; } // Leave uncapped if you want free-form notes (TEXT/LONGTEXT is okay here)
 
         /// <summary>


### PR DESCRIPTION
Removed PostalCode from the ClientProfile model, and removed [String] from the Notes field in ReferringOrganizations model. These deviated from db schema causing erroneous prompting to add a new migration.