### PR TITLE
White010/#64 referral/referring organization/client workflow

### DIFF
--- a/A New Hope/Controllers/ReferralsController.cs
+++ b/A New Hope/Controllers/ReferralsController.cs
@@ -151,13 +151,21 @@ namespace A_New_Hope.Controllers
         // GET: Referrals/WizardStep1
         /// <summary>
         /// Shows Step 1 of the referral wizard:
-        /// select an existing referring organization or add a new one.
+        /// select an existing referring organization or add a new one,
+        /// then select an existing client or add a new one.
         /// </summary>
         public async Task<IActionResult> WizardStep1()
         {
             _logger.LogInformation("Loading Referral Wizard Step 1 page");
 
             var vm = new ReferralWizardStep1ViewModel();
+            vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
+
+            if (vm.HouseholdMembers.Count == 0)
+            {
+                vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
+            }
+
             await PopulateWizardStep1Dropdowns(vm);
 
             return View(vm);
@@ -166,7 +174,8 @@ namespace A_New_Hope.Controllers
         // POST: Referrals/WizardStep1
         /// <summary>
         /// Handles Step 1 of the referral wizard:
-        /// validates either existing organization selection or new organization creation.
+        /// validates either existing or new organization,
+        /// and either existing or new client.
         /// </summary>
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -174,80 +183,178 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogInformation("Attempting to submit Referral Wizard Step 1");
 
+            vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
+
             NormalizeReferralWizardStep1(vm);
             await ApplyReferralWizardStep1ValidationAsync(vm);
 
             if (!ModelState.IsValid)
             {
                 _logger.LogWarning("Referral Wizard Step 1 failed validation");
+
+                if (vm.HouseholdMembers.Count == 0)
+                {
+                    vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
+                }
+
                 await PopulateWizardStep1Dropdowns(vm);
                 return View(vm);
             }
 
-            ulong referringOrganizationId;
+            await using var transaction = await _context.Database.BeginTransactionAsync();
 
-            if (vm.HasSelectedExistingOrganization)
+            try
             {
-                referringOrganizationId = vm.SelectedReferringOrganizationId!.Value;
+                ulong referringOrganizationId;
+                ulong clientUserId;
 
-                _logger.LogInformation(
-                    "Referral Wizard Step 1 completed using existing ReferringOrganization Id {ReferringOrganizationId}",
-                    referringOrganizationId);
-            }
-            else
-            {
-                var now = DateTime.UtcNow;
-
-                var newOrganization = new ReferringOrganization
+                if (vm.HasSelectedExistingOrganization)
                 {
-                    Name = vm.NewOrganizationName!,
-                    Type = vm.NewOrganizationType,
-                    PrimaryContactName = vm.NewPrimaryContactName,
-                    Email = vm.NewEmail,
-                    PhoneNumber = vm.NewPhoneNumber,
-                    AddressLine1 = vm.NewAddressLine1,
-                    AddressLine2 = vm.NewAddressLine2,
-                    City = vm.NewCity,
-                    State = vm.NewState,
-                    PostalCode = vm.NewPostalCode,
-                    Notes = vm.NewNotes,
-                    IsActive = true,
-                    CreatedAt = now,
-                    UpdatedAt = now,
-                    CreatedByUserId = null, // Replace when auth/user tracking is added.
-                    UpdatedByUserId = null  // Replace when auth/user tracking is added.
-                };
+                    referringOrganizationId = vm.SelectedReferringOrganizationId!.Value;
 
-                _context.ReferringOrganizations.Add(newOrganization);
-
-                try
+                    _logger.LogInformation(
+                        "Referral Wizard Step 1 completed using existing ReferringOrganization Id {ReferringOrganizationId}",
+                        referringOrganizationId);
+                }
+                else
                 {
+                    var now = DateTime.UtcNow;
+
+                    var newOrganization = new ReferringOrganization
+                    {
+                        Name = vm.NewOrganizationName!,
+                        Type = vm.NewOrganizationType,
+                        PrimaryContactName = vm.NewPrimaryContactName,
+                        Email = vm.NewEmail,
+                        PhoneNumber = vm.NewPhoneNumber,
+                        AddressLine1 = vm.NewAddressLine1,
+                        AddressLine2 = vm.NewAddressLine2,
+                        City = vm.NewCity,
+                        State = vm.NewState,
+                        PostalCode = vm.NewPostalCode,
+                        Notes = vm.NewNotes,
+                        IsActive = true,
+                        CreatedAt = now,
+                        UpdatedAt = now,
+                        CreatedByUserId = null,
+                        UpdatedByUserId = null
+                    };
+
+                    _context.ReferringOrganizations.Add(newOrganization);
                     await _context.SaveChangesAsync();
+
+                    referringOrganizationId = newOrganization.Id;
+
+                    _logger.LogInformation(
+                        "Referral Wizard Step 1 created new ReferringOrganization Id {ReferringOrganizationId}",
+                        referringOrganizationId);
                 }
-                catch (DbUpdateException ex)
+
+                if (vm.HasSelectedExistingClient)
                 {
-                    _logger.LogError(ex, "Error creating new Referring Organization during Referral Wizard Step 1");
+                    clientUserId = vm.SelectedClientUserId!.Value;
 
-                    ModelState.AddModelError(string.Empty, "Unable to save new referring organization.");
-                    await PopulateWizardStep1Dropdowns(vm);
-                    return View(vm);
+                    _logger.LogInformation(
+                        "Referral Wizard Step 1 completed using existing ClientUser Id {ClientUserId}",
+                        clientUserId);
+                }
+                else
+                {
+                    var now = DateTime.UtcNow;
+
+                    var newClient = new DomainUser
+                    {
+                        Email = vm.NewClientEmail!,
+                        PhoneNumber = vm.NewClientPhoneNumber,
+                        FirstName = vm.NewClientFirstName,
+                        LastName = vm.NewClientLastName,
+                        AddressLine1 = vm.NewClientAddressLine1,
+                        AddressLine2 = vm.NewClientAddressLine2,
+                        City = vm.NewClientCity,
+                        State = vm.NewClientState,
+                        PostalCode = vm.NewClientPostalCode,
+                        DateOfBirth = vm.NewClientDateOfBirth,
+                        UserType = UserType.Client,
+                        IsActive = true,
+                        CreatedAt = now,
+                        UpdatedAt = now,
+                        CreatedByUserId = null,
+                        UpdatedByUserId = null
+                    };
+
+                    _context.DomainUsers.Add(newClient);
+                    await _context.SaveChangesAsync();
+
+                    clientUserId = newClient.Id;
+
+                    var clientProfile = new ClientProfile
+                    {
+                        UserId = clientUserId,
+                        EmploymentStatus = vm.NewClientEmploymentStatus,
+                        EarnedIncomeMonthly = vm.NewClientEarnedIncomeMonthly,
+                        IsUnhoused = vm.NewClientIsUnhoused,
+                        CreatedAt = now,
+                        UpdatedAt = now,
+                        CreatedByUserId = null,
+                        UpdatedByUserId = null
+                    };
+
+                    _context.ClientProfiles.Add(clientProfile);
+
+                    foreach (var member in vm.HouseholdMembers.Where(h => h.HasStarted))
+                    {
+                        var householdMember = new HouseholdMember
+                        {
+                            ClientUserId = clientUserId,
+                            FirstName = member.FirstName!,
+                            LastName = member.LastName!,
+                            DateOfBirth = member.DateOfBirth,
+                            AgeAsOfDate = member.AgeAsOfDate,
+                            CreatedAt = now,
+                            UpdatedAt = now,
+                            CreatedByUserId = null,
+                            UpdatedByUserId = null
+                        };
+
+                        _context.HouseholdMembers.Add(householdMember);
+                    }
+
+                    await _context.SaveChangesAsync();
+
+                    _logger.LogInformation(
+                        "Referral Wizard Step 1 created new ClientUser Id {ClientUserId} with ClientProfile and {HouseholdCount} household members",
+                        clientUserId,
+                        vm.HouseholdMembers.Count(h => h.HasStarted));
                 }
 
-                referringOrganizationId = newOrganization.Id;
+                await transaction.CommitAsync();
 
-                _logger.LogInformation(
-                    "Referral Wizard Step 1 created new ReferringOrganization Id {ReferringOrganizationId}",
-                    referringOrganizationId);
+                TempData["ReferralWizard.ReferringOrganizationId"] = referringOrganizationId.ToString();
+                TempData["ReferralWizard.ClientUserId"] = clientUserId.ToString();
+
+                TempData["SuccessMessage"] =
+                    $"Step 1 complete. Selected Referring Organization Id: {referringOrganizationId}, Client Id: {clientUserId}";
+
+                return RedirectToAction(nameof(WizardStep1));
             }
+            catch (DbUpdateException ex)
+            {
+                await transaction.RollbackAsync();
 
-            TempData["ReferralWizard.ReferringOrganizationId"] = referringOrganizationId.ToString();
+                _logger.LogError(ex, "Error saving Referral Wizard Step 1");
 
-            // Placeholder until Step 2 is built.
-            TempData["SuccessMessage"] = $"Step 1 complete. Selected Referring Organization Id: {referringOrganizationId}";
+                ModelState.AddModelError(string.Empty, "Unable to save Step 1 data.");
 
-            return RedirectToAction(nameof(WizardStep1));
+                if (vm.HouseholdMembers.Count == 0)
+                {
+                    vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
+                }
+
+                await PopulateWizardStep1Dropdowns(vm);
+                return View(vm);
+            }
         }
-
+        
         // GET: Referrals/Edit/5
         /// <summary>
         /// Shows the edit form for a single non-deleted referral.
@@ -465,6 +572,8 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogDebug("Populating dropdowns for Referral Wizard Step 1");
 
+            vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
+
             var organizations = await _context.ReferringOrganizations
                 .Where(o => o.DeletedAt == null && o.IsActive)
                 .OrderBy(o => o.Name)
@@ -478,7 +587,32 @@ namespace A_New_Hope.Controllers
                 })
                 .ToList();
 
-            _logger.LogDebug("Referral Wizard Step 1 dropdown populated with {Count} organizations", vm.ExistingOrganizations.Count);
+            var clients = await _context.DomainUsers
+                .Where(u => u.DeletedAt == null && u.UserType == UserType.Client && u.IsActive)
+                .OrderBy(u => u.LastName)
+                .ThenBy(u => u.FirstName)
+                .ThenBy(u => u.Email)
+                .ToListAsync();
+
+            vm.ExistingClients = clients
+                .Select(u => new SelectListItem
+                {
+                    Value = u.Id.ToString(),
+                    Text = string.IsNullOrWhiteSpace($"{u.LastName}{u.FirstName}".Trim())
+                        ? u.Email
+                        : $"{u.LastName ?? ""}, {u.FirstName ?? ""} ({u.Email})"
+                })
+                .ToList();
+
+            if (vm.HouseholdMembers.Count == 0)
+            {
+                vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
+            }
+
+            _logger.LogDebug(
+                "Referral Wizard Step 1 dropdowns populated with {OrganizationCount} organizations and {ClientCount} clients",
+                vm.ExistingOrganizations.Count,
+                vm.ExistingClients.Count);
         }
 
         /// <summary>
@@ -519,6 +653,27 @@ namespace A_New_Hope.Controllers
             model.NewState = NullIfWhiteSpace(model.NewState)?.ToUpperInvariant();
             model.NewPostalCode = NullIfWhiteSpace(model.NewPostalCode);
             model.NewNotes = NullIfWhiteSpace(model.NewNotes);
+
+            model.NewClientFirstName = NullIfWhiteSpace(model.NewClientFirstName);
+            model.NewClientLastName = NullIfWhiteSpace(model.NewClientLastName);
+            model.NewClientEmail = NullIfWhiteSpace(model.NewClientEmail);
+            model.NewClientPhoneNumber = NullIfWhiteSpace(model.NewClientPhoneNumber);
+            model.NewClientAddressLine1 = NullIfWhiteSpace(model.NewClientAddressLine1);
+            model.NewClientAddressLine2 = NullIfWhiteSpace(model.NewClientAddressLine2);
+            model.NewClientCity = NullIfWhiteSpace(model.NewClientCity);
+            model.NewClientState = NullIfWhiteSpace(model.NewClientState)?.ToUpperInvariant();
+            model.NewClientPostalCode = NullIfWhiteSpace(model.NewClientPostalCode);
+
+            model.NewClientEmploymentStatus = NullIfWhiteSpace(model.NewClientEmploymentStatus);
+
+            if (model.HouseholdMembers != null)
+            {
+                foreach (var member in model.HouseholdMembers)
+                {
+                    member.FirstName = NullIfWhiteSpace(member.FirstName);
+                    member.LastName = NullIfWhiteSpace(member.LastName);
+                }
+            }
         }
 
         /// <summary>
@@ -599,22 +754,21 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private async Task ApplyReferralWizardStep1ValidationAsync(ReferralWizardStep1ViewModel model)
         {
-            bool selectedExisting = model.HasSelectedExistingOrganization;
-            bool enteredNew = model.HasStartedNewOrganization;
+            // =========================================================
+            // ORGANIZATION VALIDATION
+            // =========================================================
+            bool selectedExistingOrganization = model.HasSelectedExistingOrganization;
+            bool enteredNewOrganization = model.HasStartedNewOrganization;
 
-            if (!selectedExisting && !enteredNew)
+            if (!selectedExistingOrganization && !enteredNewOrganization)
             {
                 ModelState.AddModelError(string.Empty, "Select an existing organization or enter a new organization.");
-                return;
             }
-
-            if (selectedExisting && enteredNew)
+            else if (selectedExistingOrganization && enteredNewOrganization)
             {
                 ModelState.AddModelError(string.Empty, "Choose either an existing organization or enter a new one, not both.");
-                return;
             }
-
-            if (selectedExisting)
+            else if (selectedExistingOrganization)
             {
                 var organizationExists = await _context.ReferringOrganizations
                     .AnyAsync(o =>
@@ -626,82 +780,253 @@ namespace A_New_Hope.Controllers
                 {
                     ModelState.AddModelError(nameof(model.SelectedReferringOrganizationId), "Select a valid active referring organization.");
                 }
-
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(model.NewOrganizationName))
-            {
-                ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name is required.");
             }
             else
             {
-                if (!ContainsLetterOrDigit(model.NewOrganizationName))
+                if (string.IsNullOrWhiteSpace(model.NewOrganizationName))
                 {
-                    ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name must contain letters or numbers.");
+                    ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name is required.");
+                }
+                else
+                {
+                    if (!ContainsLetterOrDigit(model.NewOrganizationName))
+                    {
+                        ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name must contain letters or numbers.");
+                    }
+
+                    var normalizedName = model.NewOrganizationName.ToLower();
+
+                    var duplicateExists = await _context.ReferringOrganizations
+                        .AnyAsync(r =>
+                            r.DeletedAt == null &&
+                            r.Name.ToLower() == normalizedName);
+
+                    if (duplicateExists)
+                    {
+                        ModelState.AddModelError(nameof(model.NewOrganizationName), "An organization with this name already exists.");
+                    }
                 }
 
-                var normalizedName = model.NewOrganizationName.ToLower();
-
-                var duplicateExists = await _context.ReferringOrganizations
-                    .AnyAsync(r =>
-                        r.DeletedAt == null &&
-                        r.Name.ToLower() == normalizedName);
-
-                if (duplicateExists)
+                if (!string.IsNullOrWhiteSpace(model.NewOrganizationType) && !ContainsLetterOrDigit(model.NewOrganizationType))
                 {
-                    ModelState.AddModelError(nameof(model.NewOrganizationName), "An organization with this name already exists.");
+                    ModelState.AddModelError(nameof(model.NewOrganizationType), "Primary type of service must contain letters or numbers.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewPrimaryContactName) && !IsValidPersonName(model.NewPrimaryContactName))
+                {
+                    ModelState.AddModelError(nameof(model.NewPrimaryContactName), "Contact person name contains invalid characters.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewPhoneNumber) && !IsValidPhoneNumber(model.NewPhoneNumber))
+                {
+                    ModelState.AddModelError(nameof(model.NewPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewEmail) && !IsValidEmail(model.NewEmail))
+                {
+                    ModelState.AddModelError(nameof(model.NewEmail), "Email format is invalid.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewAddressLine1) && !ContainsLetterOrDigit(model.NewAddressLine1))
+                {
+                    ModelState.AddModelError(nameof(model.NewAddressLine1), "Address Line 1 must contain letters or numbers.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewAddressLine2) && !ContainsLetterOrDigit(model.NewAddressLine2))
+                {
+                    ModelState.AddModelError(nameof(model.NewAddressLine2), "Address Line 2 must contain letters or numbers.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewCity) && !IsValidCity(model.NewCity))
+                {
+                    ModelState.AddModelError(nameof(model.NewCity), "City contains invalid characters.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewState) && !IsValidUsStateCode(model.NewState))
+                {
+                    ModelState.AddModelError(nameof(model.NewState), "Enter a valid 2-letter US state code.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewPostalCode) && !IsValidUsPostalCode(model.NewPostalCode))
+                {
+                    ModelState.AddModelError(nameof(model.NewPostalCode), "Enter a valid US ZIP code or ZIP+4.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewNotes) && model.NewNotes.Length > 2000)
+                {
+                    ModelState.AddModelError(nameof(model.NewNotes), "Notes cannot exceed 2000 characters.");
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(model.NewOrganizationType) && !ContainsLetterOrDigit(model.NewOrganizationType))
-            {
-                ModelState.AddModelError(nameof(model.NewOrganizationType), "Primary type of service must contain letters or numbers.");
-            }
+            // =========================================================
+            // CLIENT VALIDATION
+            // =========================================================
+            bool selectedExistingClient = model.HasSelectedExistingClient;
+            bool enteredNewClient = model.HasStartedNewClient;
 
-            if (!string.IsNullOrWhiteSpace(model.NewPrimaryContactName) && !IsValidPersonName(model.NewPrimaryContactName))
+            if (!selectedExistingClient && !enteredNewClient)
             {
-                ModelState.AddModelError(nameof(model.NewPrimaryContactName), "Contact person name contains invalid characters.");
+                ModelState.AddModelError(string.Empty, "Select an existing client or enter a new client.");
             }
-
-            if (!string.IsNullOrWhiteSpace(model.NewPhoneNumber) && !IsValidPhoneNumber(model.NewPhoneNumber))
+            else if (selectedExistingClient && enteredNewClient)
             {
-                ModelState.AddModelError(nameof(model.NewPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+                ModelState.AddModelError(string.Empty, "Choose either an existing client or enter a new one, not both.");
             }
-
-            if (!string.IsNullOrWhiteSpace(model.NewEmail) && !IsValidEmail(model.NewEmail))
+            else if (selectedExistingClient)
             {
-                ModelState.AddModelError(nameof(model.NewEmail), "Email format is invalid.");
+                var clientExists = await _context.DomainUsers
+                    .AnyAsync(u =>
+                        u.Id == model.SelectedClientUserId &&
+                        u.DeletedAt == null &&
+                        u.UserType == UserType.Client &&
+                        u.IsActive);
+
+                if (!clientExists)
+                {
+                    ModelState.AddModelError(nameof(model.SelectedClientUserId), "Select a valid active client.");
+                }
             }
-
-            if (!string.IsNullOrWhiteSpace(model.NewAddressLine1) && !ContainsLetterOrDigit(model.NewAddressLine1))
+            else
             {
-                ModelState.AddModelError(nameof(model.NewAddressLine1), "Address Line 1 must contain letters or numbers.");
-            }
+                if (string.IsNullOrWhiteSpace(model.NewClientFirstName))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientFirstName), "First name is required.");
+                }
+                else if (!IsValidPersonName(model.NewClientFirstName))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientFirstName), "First name contains invalid characters.");
+                }
 
-            if (!string.IsNullOrWhiteSpace(model.NewAddressLine2) && !ContainsLetterOrDigit(model.NewAddressLine2))
-            {
-                ModelState.AddModelError(nameof(model.NewAddressLine2), "Address Line 2 must contain letters or numbers.");
-            }
+                if (string.IsNullOrWhiteSpace(model.NewClientLastName))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientLastName), "Last name is required.");
+                }
+                else if (!IsValidPersonName(model.NewClientLastName))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientLastName), "Last name contains invalid characters.");
+                }
 
-            if (!string.IsNullOrWhiteSpace(model.NewCity) && !IsValidCity(model.NewCity))
-            {
-                ModelState.AddModelError(nameof(model.NewCity), "City contains invalid characters.");
-            }
+                if (string.IsNullOrWhiteSpace(model.NewClientEmail))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientEmail), "Email is required.");
+                }
+                else if (!IsValidEmail(model.NewClientEmail))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientEmail), "Email format is invalid.");
+                }
+                else
+                {
+                    var duplicateClientExists = await _context.DomainUsers
+                        .AnyAsync(u =>
+                            u.DeletedAt == null &&
+                            u.UserType == UserType.Client &&
+                            u.Email.ToLower() == model.NewClientEmail.ToLower());
 
-            if (!string.IsNullOrWhiteSpace(model.NewState) && !IsValidUsStateCode(model.NewState))
-            {
-                ModelState.AddModelError(nameof(model.NewState), "Enter a valid 2-letter US state code.");
-            }
+                    if (duplicateClientExists)
+                    {
+                        ModelState.AddModelError(nameof(model.NewClientEmail), "A client with this email address already exists.");
+                    }
+                }
 
-            if (!string.IsNullOrWhiteSpace(model.NewPostalCode) && !IsValidUsPostalCode(model.NewPostalCode))
-            {
-                ModelState.AddModelError(nameof(model.NewPostalCode), "Enter a valid US ZIP code or ZIP+4.");
-            }
+                if (!string.IsNullOrWhiteSpace(model.NewClientPhoneNumber) && !IsValidPhoneNumber(model.NewClientPhoneNumber))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+                }
 
-            if (!string.IsNullOrWhiteSpace(model.NewNotes) && model.NewNotes.Length > 2000)
-            {
-                ModelState.AddModelError(nameof(model.NewNotes), "Notes cannot exceed 2000 characters.");
+                if (!string.IsNullOrWhiteSpace(model.NewClientAddressLine1) && !ContainsLetterOrDigit(model.NewClientAddressLine1))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientAddressLine1), "Address Line 1 must contain letters or numbers.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewClientAddressLine2) && !ContainsLetterOrDigit(model.NewClientAddressLine2))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientAddressLine2), "Address Line 2 must contain letters or numbers.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewClientCity) && !IsValidCity(model.NewClientCity))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientCity), "City contains invalid characters.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewClientState) && !IsValidUsStateCode(model.NewClientState))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientState), "Enter a valid 2-letter US state code.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.NewClientPostalCode) && !IsValidUsPostalCode(model.NewClientPostalCode))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientPostalCode), "Enter a valid US ZIP code or ZIP+4.");
+                }
+
+                if (model.NewClientDateOfBirth.HasValue && model.NewClientDateOfBirth.Value > DateOnly.FromDateTime(DateTime.UtcNow))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientDateOfBirth), "Date of Birth cannot be in the future.");
+                }
+
+                // =========================================================
+                // CLIENT PROFILE VALIDATION
+                // =========================================================
+                if (!string.IsNullOrWhiteSpace(model.NewClientEmploymentStatus) &&
+                    !Regex.IsMatch(model.NewClientEmploymentStatus, @"^[A-Za-z0-9\s'.-]*$"))
+                {
+                    ModelState.AddModelError(nameof(model.NewClientEmploymentStatus), "Employment status contains invalid characters.");
+                }
+
+                if (model.NewClientEarnedIncomeMonthly.HasValue && model.NewClientEarnedIncomeMonthly.Value < 0)
+                {
+                    ModelState.AddModelError(nameof(model.NewClientEarnedIncomeMonthly), "Monthly earned income must be 0 or greater.");
+                }
+
+                // =========================================================
+                // HOUSEHOLD MEMBER VALIDATION
+                // =========================================================
+                if (model.HouseholdMembers != null)
+                {
+                    for (int i = 0; i < model.HouseholdMembers.Count; i++)
+                    {
+                        var member = model.HouseholdMembers[i];
+
+                        if (!member.HasStarted)
+                        {
+                            continue;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(member.FirstName))
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].FirstName", "First name is required.");
+                        }
+                        else if (!IsValidPersonName(member.FirstName))
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].FirstName", "First name contains invalid characters.");
+                        }
+
+                        if (string.IsNullOrWhiteSpace(member.LastName))
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].LastName", "Last name is required.");
+                        }
+                        else if (!IsValidPersonName(member.LastName))
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].LastName", "Last name contains invalid characters.");
+                        }
+
+                        if (member.DateOfBirth.HasValue && member.DateOfBirth.Value.Date > DateTime.UtcNow.Date)
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].DateOfBirth", "Date of Birth cannot be in the future.");
+                        }
+
+                        if (member.AgeAsOfDate.HasValue && member.AgeAsOfDate.Value.Date > DateTime.UtcNow.Date)
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].AgeAsOfDate", "Age As Of Date cannot be in the future.");
+                        }
+
+                        if (member.DateOfBirth.HasValue &&
+                            member.AgeAsOfDate.HasValue &&
+                            member.AgeAsOfDate.Value.Date < member.DateOfBirth.Value.Date)
+                        {
+                            ModelState.AddModelError($"HouseholdMembers[{i}].AgeAsOfDate", "Age As Of Date cannot be earlier than Date of Birth.");
+                        }
+                    }
+                }
             }
         }
 

--- a/A New Hope/Controllers/ReferralsController.cs
+++ b/A New Hope/Controllers/ReferralsController.cs
@@ -10,12 +10,14 @@ namespace A_New_Hope.Controllers
 {
     /// <summary>
     /// Manages create, read, update, and soft delete operations for referrals,
-    /// plus Step 1 of the referral wizard workflow.
+    /// plus the multi-step referral wizard workflow.
     /// </summary>
     public class ReferralsController : Controller
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<ReferralsController> _logger;
+
+        private const string ReferralWizardSessionKey = "ReferralWizard.Step1";
 
         // Store the allowed 2-letter US state codes for validation.
         private static readonly HashSet<string> ValidUsStateCodes = new(StringComparer.OrdinalIgnoreCase)
@@ -151,15 +153,15 @@ namespace A_New_Hope.Controllers
         // GET: Referrals/WizardStep1
         /// <summary>
         /// Shows Step 1 of the referral wizard:
-        /// select an existing referring organization or add a new one,
-        /// then select an existing client or add a new one,
-        /// then enter the referral details.
+        /// collect organization, client, profile, household, and referral draft details.
+        /// This step saves nothing to the database.
         /// </summary>
         public async Task<IActionResult> WizardStep1()
         {
             _logger.LogInformation("Loading Referral Wizard Step 1 page");
 
-            var vm = new ReferralWizardStep1ViewModel();
+            var vm = LoadWizardStep1FromSession() ?? new ReferralWizardStep1ViewModel();
+
             vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
 
             if (vm.HouseholdMembers.Count == 0)
@@ -168,15 +170,13 @@ namespace A_New_Hope.Controllers
             }
 
             await PopulateWizardStep1Dropdowns(vm);
-
             return View(vm);
         }
 
         // POST: Referrals/WizardStep1
         /// <summary>
-        /// Handles Step 1 of the referral wizard:
-        /// validates either existing or new organization,
-        /// and either existing or new client.
+        /// Validates Step 1 and saves the wizard draft to session only.
+        /// No database records are created in Step 1.
         /// </summary>
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -202,25 +202,90 @@ namespace A_New_Hope.Controllers
                 return View(vm);
             }
 
+            SaveWizardStep1ToSession(vm);
+
+            _logger.LogInformation("Referral Wizard Step 1 draft saved to session");
+
+            return RedirectToAction(nameof(WizardStep2));
+        }
+
+        // GET: Referrals/WizardStep2
+        /// <summary>
+        /// Shows Step 2 of the referral wizard:
+        /// review and confirm all draft data from Step 1.
+        /// </summary>
+        public async Task<IActionResult> WizardStep2()
+        {
+            _logger.LogInformation("Loading Referral Wizard Step 2 page");
+
+            var vm = LoadWizardStep1FromSession();
+
+            if (vm == null)
+            {
+                _logger.LogWarning("Referral Wizard Step 2 requested without Step 1 session data");
+                TempData["ErrorMessage"] = "Your referral draft was not found. Please complete Step 1 again.";
+                return RedirectToAction(nameof(WizardStep1));
+            }
+
+            vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
+
+            if (vm.HouseholdMembers.Count == 0)
+            {
+                vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
+            }
+
+            await PopulateWizardStep1Dropdowns(vm);
+            return View(vm);
+        }
+
+        // POST: Referrals/WizardStep2Confirm
+        /// <summary>
+        /// Final confirmation for the wizard.
+        /// Creates organization, client, profile, household members, and referral in one transaction.
+        /// </summary>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> WizardStep2Confirm()
+        {
+            _logger.LogInformation("Attempting to confirm Referral Wizard Step 2");
+
+            var vm = LoadWizardStep1FromSession();
+
+            if (vm == null)
+            {
+                _logger.LogWarning("Referral Wizard Step 2 confirm requested without Step 1 session data");
+                TempData["ErrorMessage"] = "Your referral draft was not found. Please complete Step 1 again.";
+                return RedirectToAction(nameof(WizardStep1));
+            }
+
+            vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
+
+            NormalizeReferralWizardStep1(vm);
+            await ApplyReferralWizardStep1ValidationAsync(vm);
+
+            if (!ModelState.IsValid)
+            {
+                _logger.LogWarning("Referral Wizard Step 2 confirm failed validation re-check");
+                await PopulateWizardStep1Dropdowns(vm);
+                return View("WizardStep2", vm);
+            }
+
             await using var transaction = await _context.Database.BeginTransactionAsync();
 
             try
             {
+                var now = DateTime.UtcNow;
+
                 ulong referringOrganizationId;
                 ulong clientUserId;
 
+                // Organization
                 if (vm.HasSelectedExistingOrganization)
                 {
                     referringOrganizationId = vm.SelectedReferringOrganizationId!.Value;
-
-                    _logger.LogInformation(
-                        "Referral Wizard Step 1 completed using existing ReferringOrganization Id {ReferringOrganizationId}",
-                        referringOrganizationId);
                 }
                 else
                 {
-                    var now = DateTime.UtcNow;
-
                     var newOrganization = new ReferringOrganization
                     {
                         Name = vm.NewOrganizationName!,
@@ -245,24 +310,15 @@ namespace A_New_Hope.Controllers
                     await _context.SaveChangesAsync();
 
                     referringOrganizationId = newOrganization.Id;
-
-                    _logger.LogInformation(
-                        "Referral Wizard Step 1 created new ReferringOrganization Id {ReferringOrganizationId}",
-                        referringOrganizationId);
                 }
 
+                // Client / Profile / Household
                 if (vm.HasSelectedExistingClient)
                 {
                     clientUserId = vm.SelectedClientUserId!.Value;
-
-                    _logger.LogInformation(
-                        "Referral Wizard Step 1 completed using existing ClientUser Id {ClientUserId}",
-                        clientUserId);
                 }
                 else
                 {
-                    var now = DateTime.UtcNow;
-
                     var newClient = new DomainUser
                     {
                         Email = vm.NewClientEmail!,
@@ -321,50 +377,50 @@ namespace A_New_Hope.Controllers
                     }
 
                     await _context.SaveChangesAsync();
-
-                    _logger.LogInformation(
-                        "Referral Wizard Step 1 created new ClientUser Id {ClientUserId} with ClientProfile and {HouseholdCount} household members",
-                        clientUserId,
-                        vm.HouseholdMembers.Count(h => h.HasStarted));
                 }
+
+                // Referral
+                var referral = new Referral
+                {
+                    ClientUserId = clientUserId,
+                    ReferringOrganizationId = referringOrganizationId,
+                    ReferredOn = vm.ReferredOn!.Value,
+                    Status = vm.Status!.Value,
+                    ValidFrom = vm.ValidFrom,
+                    ValidTo = vm.ValidTo,
+                    ReferredByName = vm.ReferredByName,
+                    ReferredByPhoneNumber = vm.ReferredByPhoneNumber,
+                    ReferredByEmail = vm.ReferredByEmail,
+                    Notes = vm.ReferralNotes,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                    CreatedByUserId = null,
+                    UpdatedByUserId = null
+                };
+
+                _context.Referrals.Add(referral);
+                await _context.SaveChangesAsync();
 
                 await transaction.CommitAsync();
 
-                TempData["ReferralWizard.ReferringOrganizationId"] = referringOrganizationId.ToString();
-                TempData["ReferralWizard.ClientUserId"] = clientUserId.ToString();
+                ClearWizardStep1Session();
 
-                TempData["ReferralWizard.ReferredOn"] = vm.ReferredOn?.ToString("yyyy-MM-dd");
-                TempData["ReferralWizard.Status"] = vm.Status?.ToString();
-                TempData["ReferralWizard.ValidFrom"] = vm.ValidFrom?.ToString("yyyy-MM-dd");
-                TempData["ReferralWizard.ValidTo"] = vm.ValidTo?.ToString("yyyy-MM-dd");
-                TempData["ReferralWizard.ReferredByName"] = vm.ReferredByName;
-                TempData["ReferralWizard.ReferredByPhoneNumber"] = vm.ReferredByPhoneNumber;
-                TempData["ReferralWizard.ReferredByEmail"] = vm.ReferredByEmail;
-                TempData["ReferralWizard.Notes"] = vm.ReferralNotes;
+                _logger.LogInformation("Referral Wizard completed successfully with Referral Id {ReferralId}", referral.Id);
 
-                TempData["SuccessMessage"] =
-                    $"Step 1 complete. Selected Referring Organization Id: {referringOrganizationId}, Client Id: {clientUserId}";
-
-                return RedirectToAction(nameof(WizardStep1));
+                return RedirectToAction(nameof(Details), new { id = referral.Id });
             }
             catch (DbUpdateException ex)
             {
                 await transaction.RollbackAsync();
 
-                _logger.LogError(ex, "Error saving Referral Wizard Step 1");
+                _logger.LogError(ex, "Error confirming Referral Wizard Step 2");
 
-                ModelState.AddModelError(string.Empty, "Unable to save Step 1 data.");
-
-                if (vm.HouseholdMembers.Count == 0)
-                {
-                    vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
-                }
-
+                ModelState.AddModelError(string.Empty, "Unable to save the referral.");
                 await PopulateWizardStep1Dropdowns(vm);
-                return View(vm);
+                return View("WizardStep2", vm);
             }
         }
-        
+
         // GET: Referrals/Edit/5
         /// <summary>
         /// Shows the edit form for a single non-deleted referral.
@@ -543,6 +599,36 @@ namespace A_New_Hope.Controllers
         }
 
         /// <summary>
+        /// Saves the Step 1 wizard draft to session as JSON.
+        /// </summary>
+        private void SaveWizardStep1ToSession(ReferralWizardStep1ViewModel vm)
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(vm);
+            HttpContext.Session.SetString(ReferralWizardSessionKey, json);
+        }
+
+        /// <summary>
+        /// Loads the Step 1 wizard draft from session.
+        /// Returns null when no draft exists.
+        /// </summary>
+        private ReferralWizardStep1ViewModel? LoadWizardStep1FromSession()
+        {
+            var json = HttpContext.Session.GetString(ReferralWizardSessionKey);
+
+            return string.IsNullOrWhiteSpace(json)
+                ? null
+                : System.Text.Json.JsonSerializer.Deserialize<ReferralWizardStep1ViewModel>(json);
+        }
+
+        /// <summary>
+        /// Clears the current referral wizard draft from session.
+        /// </summary>
+        private void ClearWizardStep1Session()
+        {
+            HttpContext.Session.Remove(ReferralWizardSessionKey);
+        }
+
+        /// <summary>
         /// Populates dropdown lists for the create and edit forms.
         /// </summary>
         private async Task PopulateDropdowns(ulong? selectedClientUserId = null, ulong? selectedReferringOrganizationId = null)
@@ -576,11 +662,11 @@ namespace A_New_Hope.Controllers
         }
 
         /// <summary>
-        /// Populates dropdown values for Referral Wizard Step 1.
+        /// Populates dropdown values for Referral Wizard views.
         /// </summary>
         private async Task PopulateWizardStep1Dropdowns(ReferralWizardStep1ViewModel vm)
         {
-            _logger.LogDebug("Populating dropdowns for Referral Wizard Step 1");
+            _logger.LogDebug("Populating dropdowns for Referral Wizard");
 
             vm.HouseholdMembers ??= new List<ReferralWizardHouseholdMemberViewModel>();
 
@@ -630,7 +716,7 @@ namespace A_New_Hope.Controllers
             }
 
             _logger.LogDebug(
-                "Referral Wizard Step 1 dropdowns populated with {OrganizationCount} organizations, {ClientCount} clients, and {StatusCount} statuses",
+                "Referral Wizard dropdowns populated with {OrganizationCount} organizations, {ClientCount} clients, and {StatusCount} statuses",
                 vm.ExistingOrganizations.Count,
                 vm.ExistingClients.Count,
                 vm.ReferralStatusOptions.Count);
@@ -776,6 +862,7 @@ namespace A_New_Hope.Controllers
 
         /// <summary>
         /// Applies business-rule validation for Referral Wizard Step 1.
+        /// This validates the full draft but does not save anything.
         /// </summary>
         private async Task ApplyReferralWizardStep1ValidationAsync(ReferralWizardStep1ViewModel model)
         {
@@ -1052,63 +1139,63 @@ namespace A_New_Hope.Controllers
                         }
                     }
                 }
+            }
 
-                // =========================================================
-                // REFERRAL DETAILS VALIDATION
-                // =========================================================
-                if (!model.ReferredOn.HasValue)
+            // =========================================================
+            // REFERRAL DETAILS VALIDATION
+            // =========================================================
+            if (!model.ReferredOn.HasValue)
+            {
+                ModelState.AddModelError(nameof(model.ReferredOn), "Referral date is required.");
+            }
+            else
+            {
+                if (model.ReferredOn.Value.Date > DateTime.UtcNow.Date)
                 {
-                    ModelState.AddModelError(nameof(model.ReferredOn), "Referral date is required.");
-                }
-                else
-                {
-                    if (model.ReferredOn.Value.Date > DateTime.UtcNow.Date)
-                    {
-                        ModelState.AddModelError(nameof(model.ReferredOn), "Referral date cannot be in the future.");
-                    }
-
-                    if (model.ValidFrom.HasValue && model.ValidFrom.Value.Date < model.ReferredOn.Value.Date)
-                    {
-                        ModelState.AddModelError(nameof(model.ValidFrom), "Valid From cannot be earlier than Referral Date.");
-                    }
-
-                    if (model.ValidTo.HasValue && model.ValidTo.Value.Date < model.ReferredOn.Value.Date)
-                    {
-                        ModelState.AddModelError(nameof(model.ValidTo), "Valid To cannot be earlier than Referral Date.");
-                    }
+                    ModelState.AddModelError(nameof(model.ReferredOn), "Referral date cannot be in the future.");
                 }
 
-                if (!model.Status.HasValue || !Enum.IsDefined(typeof(ReferralStatus), model.Status.Value))
+                if (model.ValidFrom.HasValue && model.ValidFrom.Value.Date < model.ReferredOn.Value.Date)
                 {
-                    ModelState.AddModelError(nameof(model.Status), "Select a valid referral status.");
+                    ModelState.AddModelError(nameof(model.ValidFrom), "Valid From cannot be earlier than Referral Date.");
                 }
 
-                if (model.ValidFrom.HasValue &&
-                    model.ValidTo.HasValue &&
-                    model.ValidFrom.Value.Date > model.ValidTo.Value.Date)
+                if (model.ValidTo.HasValue && model.ValidTo.Value.Date < model.ReferredOn.Value.Date)
                 {
-                    ModelState.AddModelError(nameof(model.ValidTo), "Valid To must be on or after Valid From.");
+                    ModelState.AddModelError(nameof(model.ValidTo), "Valid To cannot be earlier than Referral Date.");
                 }
+            }
 
-                if (!string.IsNullOrWhiteSpace(model.ReferredByName) && !IsValidPersonName(model.ReferredByName))
-                {
-                    ModelState.AddModelError(nameof(model.ReferredByName), "Referrer name contains invalid characters.");
-                }
+            if (!model.Status.HasValue || !Enum.IsDefined(typeof(ReferralStatus), model.Status.Value))
+            {
+                ModelState.AddModelError(nameof(model.Status), "Select a valid referral status.");
+            }
 
-                if (!string.IsNullOrWhiteSpace(model.ReferredByPhoneNumber) && !IsValidPhoneNumber(model.ReferredByPhoneNumber))
-                {
-                    ModelState.AddModelError(nameof(model.ReferredByPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
-                }
+            if (model.ValidFrom.HasValue &&
+                model.ValidTo.HasValue &&
+                model.ValidFrom.Value.Date > model.ValidTo.Value.Date)
+            {
+                ModelState.AddModelError(nameof(model.ValidTo), "Valid To must be on or after Valid From.");
+            }
 
-                if (!string.IsNullOrWhiteSpace(model.ReferredByEmail) && !IsValidEmail(model.ReferredByEmail))
-                {
-                    ModelState.AddModelError(nameof(model.ReferredByEmail), "Email format is invalid.");
-                }
+            if (!string.IsNullOrWhiteSpace(model.ReferredByName) && !IsValidPersonName(model.ReferredByName))
+            {
+                ModelState.AddModelError(nameof(model.ReferredByName), "Referrer name contains invalid characters.");
+            }
 
-                if (!string.IsNullOrWhiteSpace(model.ReferralNotes) && model.ReferralNotes.Length > 2000)
-                {
-                    ModelState.AddModelError(nameof(model.ReferralNotes), "Notes cannot exceed 2000 characters.");
-                }
+            if (!string.IsNullOrWhiteSpace(model.ReferredByPhoneNumber) && !IsValidPhoneNumber(model.ReferredByPhoneNumber))
+            {
+                ModelState.AddModelError(nameof(model.ReferredByPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.ReferredByEmail) && !IsValidEmail(model.ReferredByEmail))
+            {
+                ModelState.AddModelError(nameof(model.ReferredByEmail), "Email format is invalid.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.ReferralNotes) && model.ReferralNotes.Length > 2000)
+            {
+                ModelState.AddModelError(nameof(model.ReferralNotes), "Notes cannot exceed 2000 characters.");
             }
         }
 

--- a/A New Hope/Controllers/ReferralsController.cs
+++ b/A New Hope/Controllers/ReferralsController.cs
@@ -152,7 +152,8 @@ namespace A_New_Hope.Controllers
         /// <summary>
         /// Shows Step 1 of the referral wizard:
         /// select an existing referring organization or add a new one,
-        /// then select an existing client or add a new one.
+        /// then select an existing client or add a new one,
+        /// then enter the referral details.
         /// </summary>
         public async Task<IActionResult> WizardStep1()
         {
@@ -331,6 +332,15 @@ namespace A_New_Hope.Controllers
 
                 TempData["ReferralWizard.ReferringOrganizationId"] = referringOrganizationId.ToString();
                 TempData["ReferralWizard.ClientUserId"] = clientUserId.ToString();
+
+                TempData["ReferralWizard.ReferredOn"] = vm.ReferredOn?.ToString("yyyy-MM-dd");
+                TempData["ReferralWizard.Status"] = vm.Status?.ToString();
+                TempData["ReferralWizard.ValidFrom"] = vm.ValidFrom?.ToString("yyyy-MM-dd");
+                TempData["ReferralWizard.ValidTo"] = vm.ValidTo?.ToString("yyyy-MM-dd");
+                TempData["ReferralWizard.ReferredByName"] = vm.ReferredByName;
+                TempData["ReferralWizard.ReferredByPhoneNumber"] = vm.ReferredByPhoneNumber;
+                TempData["ReferralWizard.ReferredByEmail"] = vm.ReferredByEmail;
+                TempData["ReferralWizard.Notes"] = vm.ReferralNotes;
 
                 TempData["SuccessMessage"] =
                     $"Step 1 complete. Selected Referring Organization Id: {referringOrganizationId}, Client Id: {clientUserId}";
@@ -604,15 +614,26 @@ namespace A_New_Hope.Controllers
                 })
                 .ToList();
 
+            vm.ReferralStatusOptions = Enum.GetValues(typeof(ReferralStatus))
+                .Cast<ReferralStatus>()
+                .Select(status => new SelectListItem
+                {
+                    Value = status.ToString(),
+                    Text = status.ToString(),
+                    Selected = vm.Status.HasValue && vm.Status.Value == status
+                })
+                .ToList();
+
             if (vm.HouseholdMembers.Count == 0)
             {
                 vm.HouseholdMembers.Add(new ReferralWizardHouseholdMemberViewModel());
             }
 
             _logger.LogDebug(
-                "Referral Wizard Step 1 dropdowns populated with {OrganizationCount} organizations and {ClientCount} clients",
+                "Referral Wizard Step 1 dropdowns populated with {OrganizationCount} organizations, {ClientCount} clients, and {StatusCount} statuses",
                 vm.ExistingOrganizations.Count,
-                vm.ExistingClients.Count);
+                vm.ExistingClients.Count,
+                vm.ReferralStatusOptions.Count);
         }
 
         /// <summary>
@@ -663,8 +684,12 @@ namespace A_New_Hope.Controllers
             model.NewClientCity = NullIfWhiteSpace(model.NewClientCity);
             model.NewClientState = NullIfWhiteSpace(model.NewClientState)?.ToUpperInvariant();
             model.NewClientPostalCode = NullIfWhiteSpace(model.NewClientPostalCode);
-
             model.NewClientEmploymentStatus = NullIfWhiteSpace(model.NewClientEmploymentStatus);
+
+            model.ReferredByName = NullIfWhiteSpace(model.ReferredByName);
+            model.ReferredByPhoneNumber = NullIfWhiteSpace(model.ReferredByPhoneNumber);
+            model.ReferredByEmail = NullIfWhiteSpace(model.ReferredByEmail);
+            model.ReferralNotes = NullIfWhiteSpace(model.ReferralNotes);
 
             if (model.HouseholdMembers != null)
             {
@@ -1026,6 +1051,63 @@ namespace A_New_Hope.Controllers
                             ModelState.AddModelError($"HouseholdMembers[{i}].AgeAsOfDate", "Age As Of Date cannot be earlier than Date of Birth.");
                         }
                     }
+                }
+
+                // =========================================================
+                // REFERRAL DETAILS VALIDATION
+                // =========================================================
+                if (!model.ReferredOn.HasValue)
+                {
+                    ModelState.AddModelError(nameof(model.ReferredOn), "Referral date is required.");
+                }
+                else
+                {
+                    if (model.ReferredOn.Value.Date > DateTime.UtcNow.Date)
+                    {
+                        ModelState.AddModelError(nameof(model.ReferredOn), "Referral date cannot be in the future.");
+                    }
+
+                    if (model.ValidFrom.HasValue && model.ValidFrom.Value.Date < model.ReferredOn.Value.Date)
+                    {
+                        ModelState.AddModelError(nameof(model.ValidFrom), "Valid From cannot be earlier than Referral Date.");
+                    }
+
+                    if (model.ValidTo.HasValue && model.ValidTo.Value.Date < model.ReferredOn.Value.Date)
+                    {
+                        ModelState.AddModelError(nameof(model.ValidTo), "Valid To cannot be earlier than Referral Date.");
+                    }
+                }
+
+                if (!model.Status.HasValue || !Enum.IsDefined(typeof(ReferralStatus), model.Status.Value))
+                {
+                    ModelState.AddModelError(nameof(model.Status), "Select a valid referral status.");
+                }
+
+                if (model.ValidFrom.HasValue &&
+                    model.ValidTo.HasValue &&
+                    model.ValidFrom.Value.Date > model.ValidTo.Value.Date)
+                {
+                    ModelState.AddModelError(nameof(model.ValidTo), "Valid To must be on or after Valid From.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.ReferredByName) && !IsValidPersonName(model.ReferredByName))
+                {
+                    ModelState.AddModelError(nameof(model.ReferredByName), "Referrer name contains invalid characters.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.ReferredByPhoneNumber) && !IsValidPhoneNumber(model.ReferredByPhoneNumber))
+                {
+                    ModelState.AddModelError(nameof(model.ReferredByPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.ReferredByEmail) && !IsValidEmail(model.ReferredByEmail))
+                {
+                    ModelState.AddModelError(nameof(model.ReferredByEmail), "Email format is invalid.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(model.ReferralNotes) && model.ReferralNotes.Length > 2000)
+                {
+                    ModelState.AddModelError(nameof(model.ReferralNotes), "Notes cannot exceed 2000 characters.");
                 }
             }
         }

--- a/A New Hope/Controllers/ReferralsController.cs
+++ b/A New Hope/Controllers/ReferralsController.cs
@@ -1,5 +1,6 @@
 using A_New_Hope.Data;
 using A_New_Hope.Models;
+using A_New_Hope.Models.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
@@ -8,12 +9,23 @@ using System.Text.RegularExpressions;
 namespace A_New_Hope.Controllers
 {
     /// <summary>
-    /// Manages create, read, update, and soft delete operations for referrals.
+    /// Manages create, read, update, and soft delete operations for referrals,
+    /// plus Step 1 of the referral wizard workflow.
     /// </summary>
     public class ReferralsController : Controller
     {
         private readonly ApplicationDbContext _context;
         private readonly ILogger<ReferralsController> _logger;
+
+        // Store the allowed 2-letter US state codes for validation.
+        private static readonly HashSet<string> ValidUsStateCodes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA",
+            "HI","ID","IL","IN","IA","KS","KY","LA","ME","MD",
+            "MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+            "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC",
+            "SD","TN","TX","UT","VT","VA","WA","WV","WI","WY","DC"
+        };
 
         /// <summary>
         /// Creates the controller with the required database context and logger.
@@ -32,7 +44,6 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogInformation("Loading Referrals Index page");
 
-            // Retrieve active referrals with related client and organization display data.
             var referrals = await _context.Referrals
                 .Where(r => r.DeletedAt == null)
                 .Include(r => r.ClientUser)
@@ -52,7 +63,6 @@ namespace A_New_Hope.Controllers
         /// </summary>
         public async Task<IActionResult> Details(ulong? id)
         {
-            // Reject requests with no id.
             if (id == null)
             {
                 _logger.LogWarning("Details requested with null Id");
@@ -61,14 +71,12 @@ namespace A_New_Hope.Controllers
 
             _logger.LogInformation("Fetching details for Referral Id {Id}", id);
 
-            // Retrieve the requested active referral with related client and organization data.
             var referral = await _context.Referrals
                 .Where(r => r.DeletedAt == null)
                 .Include(r => r.ClientUser)
                 .Include(r => r.ReferringOrganization)
                 .FirstOrDefaultAsync(m => m.Id == id);
 
-            // Return not found when the referral does not exist.
             if (referral == null)
             {
                 _logger.LogWarning("Referral Id {Id} not found", id);
@@ -86,7 +94,6 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogInformation("Loading Create Referral page");
 
-            // Populate dropdown values for the create form.
             await PopulateDropdowns();
             return View();
         }
@@ -101,17 +108,14 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogInformation("Attempting to create Referral for ClientUserId {ClientUserId}", referral.ClientUserId);
 
-            // Remove navigation properties that are not posted by the form.
             ModelState.Remove(nameof(Referral.ClientUser));
             ModelState.Remove(nameof(Referral.ReferringOrganization));
             ModelState.Remove(nameof(Referral.CreatedByUser));
             ModelState.Remove(nameof(Referral.UpdatedByUser));
 
-            // Normalize incoming values before business-rule validation.
             NormalizeReferral(referral);
             await ApplyReferralValidationAsync(referral);
 
-            // Return the form with dropdowns restored when validation fails.
             if (!ModelState.IsValid)
             {
                 _logger.LogWarning("Create Referral failed validation for ClientUserId {ClientUserId}", referral.ClientUserId);
@@ -119,14 +123,12 @@ namespace A_New_Hope.Controllers
                 return View(referral);
             }
 
-            // Set audit fields for the new referral record.
             var now = DateTime.UtcNow;
             referral.CreatedAt = now;
             referral.UpdatedAt = now;
             referral.CreatedByUserId = null; // Replace when auth/user tracking is added.
             referral.UpdatedByUserId = null; // Replace when auth/user tracking is added.
 
-            // Queue the new referral for insert.
             _context.Add(referral);
 
             try
@@ -146,13 +148,112 @@ namespace A_New_Hope.Controllers
             }
         }
 
+        // GET: Referrals/WizardStep1
+        /// <summary>
+        /// Shows Step 1 of the referral wizard:
+        /// select an existing referring organization or add a new one.
+        /// </summary>
+        public async Task<IActionResult> WizardStep1()
+        {
+            _logger.LogInformation("Loading Referral Wizard Step 1 page");
+
+            var vm = new ReferralWizardStep1ViewModel();
+            await PopulateWizardStep1Dropdowns(vm);
+
+            return View(vm);
+        }
+
+        // POST: Referrals/WizardStep1
+        /// <summary>
+        /// Handles Step 1 of the referral wizard:
+        /// validates either existing organization selection or new organization creation.
+        /// </summary>
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> WizardStep1(ReferralWizardStep1ViewModel vm)
+        {
+            _logger.LogInformation("Attempting to submit Referral Wizard Step 1");
+
+            NormalizeReferralWizardStep1(vm);
+            await ApplyReferralWizardStep1ValidationAsync(vm);
+
+            if (!ModelState.IsValid)
+            {
+                _logger.LogWarning("Referral Wizard Step 1 failed validation");
+                await PopulateWizardStep1Dropdowns(vm);
+                return View(vm);
+            }
+
+            ulong referringOrganizationId;
+
+            if (vm.HasSelectedExistingOrganization)
+            {
+                referringOrganizationId = vm.SelectedReferringOrganizationId!.Value;
+
+                _logger.LogInformation(
+                    "Referral Wizard Step 1 completed using existing ReferringOrganization Id {ReferringOrganizationId}",
+                    referringOrganizationId);
+            }
+            else
+            {
+                var now = DateTime.UtcNow;
+
+                var newOrganization = new ReferringOrganization
+                {
+                    Name = vm.NewOrganizationName!,
+                    Type = vm.NewOrganizationType,
+                    PrimaryContactName = vm.NewPrimaryContactName,
+                    Email = vm.NewEmail,
+                    PhoneNumber = vm.NewPhoneNumber,
+                    AddressLine1 = vm.NewAddressLine1,
+                    AddressLine2 = vm.NewAddressLine2,
+                    City = vm.NewCity,
+                    State = vm.NewState,
+                    PostalCode = vm.NewPostalCode,
+                    Notes = vm.NewNotes,
+                    IsActive = true,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                    CreatedByUserId = null, // Replace when auth/user tracking is added.
+                    UpdatedByUserId = null  // Replace when auth/user tracking is added.
+                };
+
+                _context.ReferringOrganizations.Add(newOrganization);
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Error creating new Referring Organization during Referral Wizard Step 1");
+
+                    ModelState.AddModelError(string.Empty, "Unable to save new referring organization.");
+                    await PopulateWizardStep1Dropdowns(vm);
+                    return View(vm);
+                }
+
+                referringOrganizationId = newOrganization.Id;
+
+                _logger.LogInformation(
+                    "Referral Wizard Step 1 created new ReferringOrganization Id {ReferringOrganizationId}",
+                    referringOrganizationId);
+            }
+
+            TempData["ReferralWizard.ReferringOrganizationId"] = referringOrganizationId.ToString();
+
+            // Placeholder until Step 2 is built.
+            TempData["SuccessMessage"] = $"Step 1 complete. Selected Referring Organization Id: {referringOrganizationId}";
+
+            return RedirectToAction(nameof(WizardStep1));
+        }
+
         // GET: Referrals/Edit/5
         /// <summary>
         /// Shows the edit form for a single non-deleted referral.
         /// </summary>
         public async Task<IActionResult> Edit(ulong? id)
         {
-            // Reject requests with no id.
             if (id == null)
             {
                 _logger.LogWarning("Edit requested with null Id");
@@ -161,18 +262,15 @@ namespace A_New_Hope.Controllers
 
             _logger.LogInformation("Loading Edit page for Referral Id {Id}", id);
 
-            // Retrieve the requested active referral for editing.
             var referral = await _context.Referrals
                 .FirstOrDefaultAsync(r => r.Id == id && r.DeletedAt == null);
 
-            // Return not found when the referral does not exist.
             if (referral == null)
             {
                 _logger.LogWarning("Referral Id {Id} not found for edit", id);
                 return NotFound();
             }
 
-            // Populate dropdown values using the current record selections.
             await PopulateDropdowns(referral.ClientUserId, referral.ReferringOrganizationId);
             return View(referral);
         }
@@ -187,24 +285,20 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogInformation("Attempting to edit Referral Id {Id}", id);
 
-            // Ensure the route id matches the posted model id.
             if (id != formModel.Id)
             {
                 _logger.LogWarning("Edit mismatch: route Id {RouteId} vs model Id {ModelId}", id, formModel.Id);
                 return NotFound();
             }
 
-            // Remove navigation properties that are not posted by the form.
             ModelState.Remove(nameof(Referral.ClientUser));
             ModelState.Remove(nameof(Referral.ReferringOrganization));
             ModelState.Remove(nameof(Referral.CreatedByUser));
             ModelState.Remove(nameof(Referral.UpdatedByUser));
 
-            // Normalize incoming values before business-rule validation.
             NormalizeReferral(formModel);
             await ApplyReferralValidationAsync(formModel, formModel.Id);
 
-            // Return the form with dropdowns restored when validation fails.
             if (!ModelState.IsValid)
             {
                 _logger.LogWarning("Edit Referral failed validation for Id {Id}", id);
@@ -212,18 +306,15 @@ namespace A_New_Hope.Controllers
                 return View(formModel);
             }
 
-            // Retrieve the existing active referral record.
             var existing = await _context.Referrals
                 .FirstOrDefaultAsync(r => r.Id == id && r.DeletedAt == null);
 
-            // Return not found when the target record no longer exists.
             if (existing == null)
             {
                 _logger.LogWarning("Referral Id {Id} not found during edit save", id);
                 return NotFound();
             }
 
-            // Copy validated form values into the tracked entity.
             existing.ClientUserId = formModel.ClientUserId;
             existing.ReferringOrganizationId = formModel.ReferringOrganizationId;
             existing.ReferredOn = formModel.ReferredOn;
@@ -247,7 +338,6 @@ namespace A_New_Hope.Controllers
             }
             catch (DbUpdateConcurrencyException)
             {
-                // Check whether the record was deleted during the edit attempt.
                 if (!await ReferralExists(formModel.Id))
                 {
                     _logger.LogWarning("Referral Id {Id} no longer exists during concurrency check", id);
@@ -272,7 +362,6 @@ namespace A_New_Hope.Controllers
         /// </summary>
         public async Task<IActionResult> Delete(ulong? id)
         {
-            // Reject requests with no id.
             if (id == null)
             {
                 _logger.LogWarning("Delete requested with null Id");
@@ -281,14 +370,12 @@ namespace A_New_Hope.Controllers
 
             _logger.LogInformation("Loading Delete confirmation for Referral Id {Id}", id);
 
-            // Retrieve the requested active referral with related client and organization data.
             var referral = await _context.Referrals
                 .Where(r => r.DeletedAt == null)
                 .Include(r => r.ClientUser)
                 .Include(r => r.ReferringOrganization)
                 .FirstOrDefaultAsync(m => m.Id == id);
 
-            // Return not found when the referral does not exist.
             if (referral == null)
             {
                 _logger.LogWarning("Referral Id {Id} not found for delete", id);
@@ -308,18 +395,15 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogWarning("Soft deleting Referral Id {Id}", id);
 
-            // Retrieve the active referral targeted for soft delete.
             var referral = await _context.Referrals
                 .FirstOrDefaultAsync(r => r.Id == id && r.DeletedAt == null);
 
-            // Return not found when the referral does not exist.
             if (referral == null)
             {
                 _logger.LogWarning("Referral Id {Id} not found during delete", id);
                 return NotFound();
             }
 
-            // Apply soft-delete and audit values.
             referral.DeletedAt = DateTime.UtcNow;
             referral.UpdatedAt = DateTime.UtcNow;
             referral.UpdatedByUserId = null; // Replace when auth/user tracking is added.
@@ -348,7 +432,6 @@ namespace A_New_Hope.Controllers
         {
             _logger.LogDebug("Populating dropdowns for Referrals");
 
-            // Retrieve active users for the client dropdown.
             var users = await _context.DomainUsers
                 .Where(u => u.DeletedAt == null)
                 .OrderBy(u => u.LastName)
@@ -356,7 +439,6 @@ namespace A_New_Hope.Controllers
                 .ThenBy(u => u.Email)
                 .ToListAsync();
 
-            // Build display-friendly user dropdown options.
             var userOptions = users
                 .Select(u => new
                 {
@@ -365,13 +447,11 @@ namespace A_New_Hope.Controllers
                 })
                 .ToList();
 
-            // Retrieve active referring organizations for the organization dropdown.
             var organizations = await _context.ReferringOrganizations
                 .Where(o => o.DeletedAt == null)
                 .OrderBy(o => o.Name)
                 .ToListAsync();
 
-            // Store the client and organization dropdown options in ViewData.
             ViewData["ClientUserId"] = new SelectList(userOptions, "Id", "DisplayName", selectedClientUserId);
             ViewData["ReferringOrganizationId"] = new SelectList(organizations, "Id", "Name", selectedReferringOrganizationId);
 
@@ -379,11 +459,33 @@ namespace A_New_Hope.Controllers
         }
 
         /// <summary>
+        /// Populates dropdown values for Referral Wizard Step 1.
+        /// </summary>
+        private async Task PopulateWizardStep1Dropdowns(ReferralWizardStep1ViewModel vm)
+        {
+            _logger.LogDebug("Populating dropdowns for Referral Wizard Step 1");
+
+            var organizations = await _context.ReferringOrganizations
+                .Where(o => o.DeletedAt == null && o.IsActive)
+                .OrderBy(o => o.Name)
+                .ToListAsync();
+
+            vm.ExistingOrganizations = organizations
+                .Select(o => new SelectListItem
+                {
+                    Value = o.Id.ToString(),
+                    Text = o.Name
+                })
+                .ToList();
+
+            _logger.LogDebug("Referral Wizard Step 1 dropdown populated with {Count} organizations", vm.ExistingOrganizations.Count);
+        }
+
+        /// <summary>
         /// Returns true if the non-deleted referral exists.
         /// </summary>
         private async Task<bool> ReferralExists(ulong id)
         {
-            // Check whether the requested active referral still exists.
             return await _context.Referrals.AnyAsync(e => e.Id == id && e.DeletedAt == null);
         }
 
@@ -392,7 +494,6 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private static void NormalizeReferral(Referral model)
         {
-            // Normalize optional string values before validation and save.
             model.ReferredByName = NullIfWhiteSpace(model.ReferredByName);
             model.ReferredByPhoneNumber = NullIfWhiteSpace(model.ReferredByPhoneNumber);
             model.ReferredByEmail = NullIfWhiteSpace(model.ReferredByEmail);
@@ -400,11 +501,31 @@ namespace A_New_Hope.Controllers
         }
 
         /// <summary>
+        /// Trims strings and converts blank optional values to null for Wizard Step 1.
+        /// </summary>
+        private static void NormalizeReferralWizardStep1(ReferralWizardStep1ViewModel model)
+        {
+            model.NewOrganizationName = string.IsNullOrWhiteSpace(model.NewOrganizationName)
+                ? null
+                : model.NewOrganizationName.Trim();
+
+            model.NewOrganizationType = NullIfWhiteSpace(model.NewOrganizationType);
+            model.NewPrimaryContactName = NullIfWhiteSpace(model.NewPrimaryContactName);
+            model.NewEmail = NullIfWhiteSpace(model.NewEmail);
+            model.NewPhoneNumber = NullIfWhiteSpace(model.NewPhoneNumber);
+            model.NewAddressLine1 = NullIfWhiteSpace(model.NewAddressLine1);
+            model.NewAddressLine2 = NullIfWhiteSpace(model.NewAddressLine2);
+            model.NewCity = NullIfWhiteSpace(model.NewCity);
+            model.NewState = NullIfWhiteSpace(model.NewState)?.ToUpperInvariant();
+            model.NewPostalCode = NullIfWhiteSpace(model.NewPostalCode);
+            model.NewNotes = NullIfWhiteSpace(model.NewNotes);
+        }
+
+        /// <summary>
         /// Applies business-rule validation beyond data annotations.
         /// </summary>
         private async Task ApplyReferralValidationAsync(Referral model, ulong? currentId = null)
         {
-            // Validate that the selected client exists and is not deleted.
             var clientExists = await _context.DomainUsers
                 .AnyAsync(u =>
                     u.Id == model.ClientUserId &&
@@ -416,7 +537,6 @@ namespace A_New_Hope.Controllers
                 ModelState.AddModelError(nameof(Referral.ClientUserId), "Select a valid client.");
             }
 
-            // Validate that the selected referring organization exists, is active, and is not deleted.
             var organizationExists = await _context.ReferringOrganizations
                 .AnyAsync(o =>
                     o.Id == model.ReferringOrganizationId &&
@@ -428,58 +548,160 @@ namespace A_New_Hope.Controllers
                 ModelState.AddModelError(nameof(Referral.ReferringOrganizationId), "Select a valid active referring organization.");
             }
 
-            // Validate that the selected referral status is defined.
             if (!Enum.IsDefined(typeof(ReferralStatus), model.Status))
             {
                 ModelState.AddModelError(nameof(Referral.Status), "Select a valid referral status.");
             }
 
-            // Prevent referral dates in the future.
             if (model.ReferredOn.Date > DateTime.UtcNow.Date)
             {
                 ModelState.AddModelError(nameof(Referral.ReferredOn), "Referral date cannot be in the future.");
             }
 
-            // Ensure the validity range is chronologically correct.
             if (model.ValidFrom.HasValue && model.ValidTo.HasValue && model.ValidFrom.Value > model.ValidTo.Value)
             {
                 ModelState.AddModelError(nameof(Referral.ValidTo), "Valid To must be on or after Valid From.");
             }
 
-            // Ensure Valid From is not earlier than Referred On.
             if (model.ValidFrom.HasValue && model.ValidFrom.Value < model.ReferredOn)
             {
                 ModelState.AddModelError(nameof(Referral.ValidFrom), "Valid From cannot be earlier than Referred On.");
             }
 
-            // Ensure Valid To is not earlier than Referred On.
             if (model.ValidTo.HasValue && model.ValidTo.Value < model.ReferredOn)
             {
                 ModelState.AddModelError(nameof(Referral.ValidTo), "Valid To cannot be earlier than Referred On.");
             }
 
-            // Validate referring contact name characters when provided.
             if (!string.IsNullOrWhiteSpace(model.ReferredByName) && !IsValidPersonName(model.ReferredByName))
             {
                 ModelState.AddModelError(nameof(Referral.ReferredByName), "Referred By Name contains invalid characters.");
             }
 
-            // Validate referring contact phone number when provided.
             if (!string.IsNullOrWhiteSpace(model.ReferredByPhoneNumber) && !IsValidPhoneNumber(model.ReferredByPhoneNumber))
             {
                 ModelState.AddModelError(nameof(Referral.ReferredByPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
             }
 
-            // Validate referring contact email when provided.
             if (!string.IsNullOrWhiteSpace(model.ReferredByEmail) && !IsValidEmail(model.ReferredByEmail))
             {
                 ModelState.AddModelError(nameof(Referral.ReferredByEmail), "Email format is invalid.");
             }
 
-            // Enforce the project note length limit when notes are provided.
             if (!string.IsNullOrWhiteSpace(model.Notes) && model.Notes.Length > 2000)
             {
                 ModelState.AddModelError(nameof(Referral.Notes), "Notes cannot exceed 2000 characters.");
+            }
+        }
+
+        /// <summary>
+        /// Applies business-rule validation for Referral Wizard Step 1.
+        /// </summary>
+        private async Task ApplyReferralWizardStep1ValidationAsync(ReferralWizardStep1ViewModel model)
+        {
+            bool selectedExisting = model.HasSelectedExistingOrganization;
+            bool enteredNew = model.HasStartedNewOrganization;
+
+            if (!selectedExisting && !enteredNew)
+            {
+                ModelState.AddModelError(string.Empty, "Select an existing organization or enter a new organization.");
+                return;
+            }
+
+            if (selectedExisting && enteredNew)
+            {
+                ModelState.AddModelError(string.Empty, "Choose either an existing organization or enter a new one, not both.");
+                return;
+            }
+
+            if (selectedExisting)
+            {
+                var organizationExists = await _context.ReferringOrganizations
+                    .AnyAsync(o =>
+                        o.Id == model.SelectedReferringOrganizationId &&
+                        o.DeletedAt == null &&
+                        o.IsActive);
+
+                if (!organizationExists)
+                {
+                    ModelState.AddModelError(nameof(model.SelectedReferringOrganizationId), "Select a valid active referring organization.");
+                }
+
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(model.NewOrganizationName))
+            {
+                ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name is required.");
+            }
+            else
+            {
+                if (!ContainsLetterOrDigit(model.NewOrganizationName))
+                {
+                    ModelState.AddModelError(nameof(model.NewOrganizationName), "Organization name must contain letters or numbers.");
+                }
+
+                var normalizedName = model.NewOrganizationName.ToLower();
+
+                var duplicateExists = await _context.ReferringOrganizations
+                    .AnyAsync(r =>
+                        r.DeletedAt == null &&
+                        r.Name.ToLower() == normalizedName);
+
+                if (duplicateExists)
+                {
+                    ModelState.AddModelError(nameof(model.NewOrganizationName), "An organization with this name already exists.");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewOrganizationType) && !ContainsLetterOrDigit(model.NewOrganizationType))
+            {
+                ModelState.AddModelError(nameof(model.NewOrganizationType), "Primary type of service must contain letters or numbers.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewPrimaryContactName) && !IsValidPersonName(model.NewPrimaryContactName))
+            {
+                ModelState.AddModelError(nameof(model.NewPrimaryContactName), "Contact person name contains invalid characters.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewPhoneNumber) && !IsValidPhoneNumber(model.NewPhoneNumber))
+            {
+                ModelState.AddModelError(nameof(model.NewPhoneNumber), "Enter a valid US phone number with 10 digits, or 11 digits starting with 1.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewEmail) && !IsValidEmail(model.NewEmail))
+            {
+                ModelState.AddModelError(nameof(model.NewEmail), "Email format is invalid.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewAddressLine1) && !ContainsLetterOrDigit(model.NewAddressLine1))
+            {
+                ModelState.AddModelError(nameof(model.NewAddressLine1), "Address Line 1 must contain letters or numbers.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewAddressLine2) && !ContainsLetterOrDigit(model.NewAddressLine2))
+            {
+                ModelState.AddModelError(nameof(model.NewAddressLine2), "Address Line 2 must contain letters or numbers.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewCity) && !IsValidCity(model.NewCity))
+            {
+                ModelState.AddModelError(nameof(model.NewCity), "City contains invalid characters.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewState) && !IsValidUsStateCode(model.NewState))
+            {
+                ModelState.AddModelError(nameof(model.NewState), "Enter a valid 2-letter US state code.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewPostalCode) && !IsValidUsPostalCode(model.NewPostalCode))
+            {
+                ModelState.AddModelError(nameof(model.NewPostalCode), "Enter a valid US ZIP code or ZIP+4.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.NewNotes) && model.NewNotes.Length > 2000)
+            {
+                ModelState.AddModelError(nameof(model.NewNotes), "Notes cannot exceed 2000 characters.");
             }
         }
 
@@ -488,8 +710,15 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private static string? NullIfWhiteSpace(string? value)
         {
-            // Convert blank strings to null after trimming.
             return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+
+        /// <summary>
+        /// Returns true when the value contains at least one letter or digit.
+        /// </summary>
+        private static bool ContainsLetterOrDigit(string value)
+        {
+            return value.Any(char.IsLetterOrDigit);
         }
 
         /// <summary>
@@ -497,22 +726,18 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private static bool IsValidPhoneNumber(string phoneNumber)
         {
-            // Reject characters outside the allowed phone number pattern.
             if (!Regex.IsMatch(phoneNumber, @"^\+?[0-9()\-\s]+$"))
             {
                 return false;
             }
 
-            // Strip formatting characters to validate digit count.
             var digitsOnly = new string(phoneNumber.Where(char.IsDigit).ToArray());
 
-            // Accept standard 10-digit US phone numbers.
             if (digitsOnly.Length == 10)
             {
                 return true;
             }
 
-            // Accept 11-digit US phone numbers only when starting with 1.
             if (digitsOnly.Length == 11 && digitsOnly.StartsWith("1"))
             {
                 return true;
@@ -526,25 +751,21 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private static bool IsValidEmail(string email)
         {
-            // Reject spaces in email addresses.
             if (email.Contains(' '))
             {
                 return false;
             }
 
-            // Require exactly one @ symbol.
             if (email.Count(c => c == '@') != 1)
             {
                 return false;
             }
 
-            // Reject consecutive periods.
             if (email.Contains(".."))
             {
                 return false;
             }
 
-            // Split the email into local and domain parts.
             var parts = email.Split('@');
             if (parts.Length != 2)
             {
@@ -554,38 +775,32 @@ namespace A_New_Hope.Controllers
             var localPart = parts[0];
             var domainPart = parts[1];
 
-            // Require non-empty local and domain parts.
             if (string.IsNullOrWhiteSpace(localPart) || string.IsNullOrWhiteSpace(domainPart))
             {
                 return false;
             }
 
-            // Reject local parts starting or ending with a period.
             if (localPart.StartsWith('.') || localPart.EndsWith('.'))
             {
                 return false;
             }
 
-            // Reject domain parts starting or ending with a period.
             if (domainPart.StartsWith('.') || domainPart.EndsWith('.'))
             {
                 return false;
             }
 
-            // Require a dot in the domain portion.
             if (!domainPart.Contains('.'))
             {
                 return false;
             }
 
-            // Reject empty domain labels.
             var domainLabels = domainPart.Split('.');
             if (domainLabels.Any(label => string.IsNullOrWhiteSpace(label)))
             {
                 return false;
             }
 
-            // Validate local and domain characters using project regex rules.
             return Regex.IsMatch(localPart, @"^[A-Za-z0-9._+\-]+$")
                 && Regex.IsMatch(domainPart, @"^[A-Za-z0-9.\-]+$");
         }
@@ -595,8 +810,31 @@ namespace A_New_Hope.Controllers
         /// </summary>
         private static bool IsValidPersonName(string name)
         {
-            // Allow letters plus common punctuation for personal names.
             return Regex.IsMatch(name, @"^[A-Za-z][A-Za-z\s'.-]*$");
+        }
+
+        /// <summary>
+        /// Validates a city name using a practical US-style character set.
+        /// </summary>
+        private static bool IsValidCity(string city)
+        {
+            return Regex.IsMatch(city, @"^[A-Za-z][A-Za-z\s'.-]*$");
+        }
+
+        /// <summary>
+        /// Validates a 2-letter US state code.
+        /// </summary>
+        private static bool IsValidUsStateCode(string state)
+        {
+            return state.Length == 2 && ValidUsStateCodes.Contains(state);
+        }
+
+        /// <summary>
+        /// Validates a US ZIP code or ZIP+4.
+        /// </summary>
+        private static bool IsValidUsPostalCode(string postalCode)
+        {
+            return Regex.IsMatch(postalCode, @"^\d{5}(-\d{4})?$");
         }
     }
 }

--- a/A New Hope/DBContext/ApplicationDBContext.cs
+++ b/A New Hope/DBContext/ApplicationDBContext.cs
@@ -137,6 +137,12 @@ namespace A_New_Hope.Data
                 entity.HasIndex(e => e.IsActive);
                 entity.HasIndex(e => e.DeletedAt);
 
+                entity.Property(e => e.DateOfBirth)
+                    .HasConversion(
+                        v => v.HasValue ? v.Value.ToDateTime(TimeOnly.MinValue) : (DateTime?)null,
+                        v => v.HasValue ? DateOnly.FromDateTime(v.Value) : (DateOnly?)null)
+                    .HasColumnType("date");
+
                 // Enum-to-string conversions
                 // Store the enum as a short string rather than an int for readability and stability.
                 entity.Property(e => e.DefaultPreference)

--- a/A New Hope/Models/ViewModels/ReferralWizardHouseholdMemberViewModel.cs
+++ b/A New Hope/Models/ViewModels/ReferralWizardHouseholdMemberViewModel.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace A_New_Hope.Models.ViewModels
+{
+    /// <summary>
+    /// View model for one optional household member row
+    /// in Referral Wizard Step 1.
+    /// </summary>
+    public class ReferralWizardHouseholdMemberViewModel
+    {
+        [Display(Name = "First Name")]
+        [MaxLength(100)]
+        public string? FirstName { get; set; }
+
+        [Display(Name = "Last Name")]
+        [MaxLength(100)]
+        public string? LastName { get; set; }
+
+        [Display(Name = "Date of Birth")]
+        [DataType(DataType.Date)]
+        public DateTime? DateOfBirth { get; set; }
+
+        [Display(Name = "Age As Of Date")]
+        [DataType(DataType.Date)]
+        public DateTime? AgeAsOfDate { get; set; }
+
+        public bool HasStarted =>
+            !string.IsNullOrWhiteSpace(FirstName) ||
+            !string.IsNullOrWhiteSpace(LastName) ||
+            DateOfBirth.HasValue ||
+            AgeAsOfDate.HasValue;
+    }
+}

--- a/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
+++ b/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
@@ -6,7 +6,8 @@ namespace A_New_Hope.Models.ViewModels
     /// <summary>
     /// View model for Referral Wizard Step 1:
     /// select an existing referring organization or add a new one,
-    /// then select an existing client or add a new one.
+    /// then select an existing client or add a new one,
+    /// then enter the referral details themselves.
     /// 
     /// When adding a new client:
     /// - core DomainUser fields are collected
@@ -187,5 +188,45 @@ namespace A_New_Hope.Models.ViewModels
             NewClientEarnedIncomeMonthly.HasValue ||
             NewClientIsUnhoused ||
             (HouseholdMembers?.Any(h => h.HasStarted) ?? false);
+
+        // =========================================================
+        // REFERRAL DETAILS
+        // =========================================================
+
+        [Required(ErrorMessage = "Referral date is required.")]
+        [Display(Name = "Referral Date")]
+        [DataType(DataType.Date)]
+        public DateTime? ReferredOn { get; set; } = DateTime.Today;
+
+        [Required(ErrorMessage = "Referral status is required.")]
+        [Display(Name = "Status")]
+        public ReferralStatus? Status { get; set; } = ReferralStatus.Pending;
+
+        [Display(Name = "Valid From")]
+        [DataType(DataType.Date)]
+        public DateTime? ValidFrom { get; set; }
+
+        [Display(Name = "Valid To")]
+        [DataType(DataType.Date)]
+        public DateTime? ValidTo { get; set; }
+
+        [Display(Name = "Referrer Name")]
+        [MaxLength(200)]
+        public string? ReferredByName { get; set; }
+
+        [Display(Name = "Referrer Phone Number")]
+        [MaxLength(25)]
+        public string? ReferredByPhoneNumber { get; set; }
+
+        [Display(Name = "Referrer Email Address")]
+        [MaxLength(254)]
+        [EmailAddress(ErrorMessage = "Please enter a valid email address.")]
+        public string? ReferredByEmail { get; set; }
+
+        [Display(Name = "Referral Notes")]
+        [MaxLength(2000)]
+        public string? ReferralNotes { get; set; }
+
+        public List<SelectListItem> ReferralStatusOptions { get; set; } = new();
     }
 }

--- a/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
+++ b/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
@@ -5,10 +5,20 @@ namespace A_New_Hope.Models.ViewModels
 {
     /// <summary>
     /// View model for Referral Wizard Step 1:
-    /// select an existing referring organization or add a new one.
+    /// select an existing referring organization or add a new one,
+    /// then select an existing client or add a new one.
+    /// 
+    /// When adding a new client:
+    /// - core DomainUser fields are collected
+    /// - ClientProfile fields are collected as a static section
+    /// - HouseholdMembers can be added optionally as a 1:M collection
     /// </summary>
     public class ReferralWizardStep1ViewModel
     {
+        // =========================================================
+        // REFERRING ORGANIZATION
+        // =========================================================
+
         [Display(Name = "Existing Organization")]
         public ulong? SelectedReferringOrganizationId { get; set; }
 
@@ -80,5 +90,102 @@ namespace A_New_Hope.Models.ViewModels
             !string.IsNullOrWhiteSpace(NewState) ||
             !string.IsNullOrWhiteSpace(NewPostalCode) ||
             !string.IsNullOrWhiteSpace(NewNotes);
+
+        // =========================================================
+        // CLIENT
+        // =========================================================
+
+        [Display(Name = "Existing Client")]
+        public ulong? SelectedClientUserId { get; set; }
+
+        [Display(Name = "First Name")]
+        [MaxLength(100)]
+        public string? NewClientFirstName { get; set; }
+
+        [Display(Name = "Last Name")]
+        [MaxLength(100)]
+        public string? NewClientLastName { get; set; }
+
+        [Display(Name = "Email Address")]
+        [MaxLength(254)]
+        public string? NewClientEmail { get; set; }
+
+        [Display(Name = "Phone Number")]
+        [MaxLength(25)]
+        public string? NewClientPhoneNumber { get; set; }
+
+        [Display(Name = "Address Line 1")]
+        [MaxLength(200)]
+        public string? NewClientAddressLine1 { get; set; }
+
+        [Display(Name = "Address Line 2")]
+        [MaxLength(200)]
+        public string? NewClientAddressLine2 { get; set; }
+
+        [Display(Name = "City")]
+        [MaxLength(100)]
+        public string? NewClientCity { get; set; }
+
+        [Display(Name = "State")]
+        [MaxLength(2)]
+        public string? NewClientState { get; set; }
+
+        [Display(Name = "ZIP Code")]
+        [MaxLength(20)]
+        public string? NewClientPostalCode { get; set; }
+
+        [Display(Name = "Date of Birth")]
+        [DataType(DataType.Date)]
+        public DateOnly? NewClientDateOfBirth { get; set; }
+
+        // =========================================================
+        // CLIENT PROFILE (static when adding a new client)
+        // =========================================================
+
+        [Display(Name = "Employment Status")]
+        [MaxLength(50)]
+        public string? NewClientEmploymentStatus { get; set; }
+
+        [Display(Name = "Monthly Earned Income")]
+        [Range(0, 9999999999.99, ErrorMessage = "Monthly earned income must be 0 or greater.")]
+        public decimal? NewClientEarnedIncomeMonthly { get; set; }
+
+        [Display(Name = "Currently Unhoused")]
+        public bool NewClientIsUnhoused { get; set; }
+
+        // =========================================================
+        // HOUSEHOLD MEMBERS (optional 1:M when adding a new client)
+        // =========================================================
+
+        public List<ReferralWizardHouseholdMemberViewModel> HouseholdMembers { get; set; } = new();
+
+        public List<SelectListItem> ExistingClients { get; set; } = new();
+
+        /// <summary>
+        /// True when the user selected an existing client.
+        /// </summary>
+        public bool HasSelectedExistingClient =>
+            SelectedClientUserId.HasValue && SelectedClientUserId.Value > 0;
+
+        /// <summary>
+        /// True when the user has started entering a new client,
+        /// including any static ClientProfile fields.
+        /// Used to determine validation path and whether the collapse should stay open.
+        /// </summary>
+        public bool HasStartedNewClient =>
+            !string.IsNullOrWhiteSpace(NewClientFirstName) ||
+            !string.IsNullOrWhiteSpace(NewClientLastName) ||
+            !string.IsNullOrWhiteSpace(NewClientEmail) ||
+            !string.IsNullOrWhiteSpace(NewClientPhoneNumber) ||
+            !string.IsNullOrWhiteSpace(NewClientAddressLine1) ||
+            !string.IsNullOrWhiteSpace(NewClientAddressLine2) ||
+            !string.IsNullOrWhiteSpace(NewClientCity) ||
+            !string.IsNullOrWhiteSpace(NewClientState) ||
+            !string.IsNullOrWhiteSpace(NewClientPostalCode) ||
+            NewClientDateOfBirth.HasValue ||
+            !string.IsNullOrWhiteSpace(NewClientEmploymentStatus) ||
+            NewClientEarnedIncomeMonthly.HasValue ||
+            NewClientIsUnhoused ||
+            (HouseholdMembers?.Any(h => h.HasStarted) ?? false);
     }
 }

--- a/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
+++ b/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System.ComponentModel.DataAnnotations;
+
+namespace A_New_Hope.Models.ViewModels
+{
+    /// <summary>
+    /// View model for Referral Wizard Step 1:
+    /// select an existing referring organization or add a new one.
+    /// </summary>
+    public class ReferralWizardStep1ViewModel
+    {
+        [Display(Name = "Existing Organization")]
+        public ulong? SelectedReferringOrganizationId { get; set; }
+
+        [Display(Name = "Organization Name")]
+        [MaxLength(200)]
+        public string? NewOrganizationName { get; set; }
+
+        [Display(Name = "Primary Type of Service")]
+        [MaxLength(100)]
+        public string? NewOrganizationType { get; set; }
+
+        [Display(Name = "Contact Person Name")]
+        [MaxLength(200)]
+        public string? NewPrimaryContactName { get; set; }
+
+        [Display(Name = "Email Address")]
+        [MaxLength(254)]
+        public string? NewEmail { get; set; }
+
+        [Display(Name = "Phone Number")]
+        [MaxLength(25)]
+        public string? NewPhoneNumber { get; set; }
+
+        [Display(Name = "Address Line 1")]
+        [MaxLength(200)]
+        public string? NewAddressLine1 { get; set; }
+
+        [Display(Name = "Address Line 2")]
+        [MaxLength(200)]
+        public string? NewAddressLine2 { get; set; }
+
+        [Display(Name = "City")]
+        [MaxLength(100)]
+        public string? NewCity { get; set; }
+
+        [Display(Name = "State")]
+        [MaxLength(2)]
+        public string? NewState { get; set; }
+
+        [Display(Name = "ZIP Code")]
+        [MaxLength(20)]
+        public string? NewPostalCode { get; set; }
+
+        [Display(Name = "Notes")]
+        [MaxLength(2000)]
+        public string? NewNotes { get; set; }
+
+        public List<SelectListItem> ExistingOrganizations { get; set; } = new();
+
+        /// <summary>
+        /// True when the user selected an existing organization.
+        /// </summary>
+        public bool HasSelectedExistingOrganization =>
+            SelectedReferringOrganizationId.HasValue && SelectedReferringOrganizationId.Value > 0;
+
+        /// <summary>
+        /// True when the user has started entering a new organization.
+        /// Used to determine validation path and whether the collapse should stay open.
+        /// </summary>
+        public bool HasStartedNewOrganization =>
+            !string.IsNullOrWhiteSpace(NewOrganizationName) ||
+            !string.IsNullOrWhiteSpace(NewOrganizationType) ||
+            !string.IsNullOrWhiteSpace(NewPrimaryContactName) ||
+            !string.IsNullOrWhiteSpace(NewEmail) ||
+            !string.IsNullOrWhiteSpace(NewPhoneNumber) ||
+            !string.IsNullOrWhiteSpace(NewAddressLine1) ||
+            !string.IsNullOrWhiteSpace(NewAddressLine2) ||
+            !string.IsNullOrWhiteSpace(NewCity) ||
+            !string.IsNullOrWhiteSpace(NewState) ||
+            !string.IsNullOrWhiteSpace(NewPostalCode) ||
+            !string.IsNullOrWhiteSpace(NewNotes);
+    }
+}

--- a/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
+++ b/A New Hope/Models/ViewModels/ReferralWizardStep1ViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.Rendering;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace A_New_Hope.Models.ViewModels
 {

--- a/A New Hope/Program.cs
+++ b/A New Hope/Program.cs
@@ -34,6 +34,18 @@ try
     builder.Services.AddRazorPages();
 
     // ------------------------------
+    // Session
+    // ------------------------------
+    builder.Services.AddDistributedMemoryCache();
+
+    builder.Services.AddSession(options =>
+    {
+        options.IdleTimeout = TimeSpan.FromMinutes(30);
+        options.Cookie.HttpOnly = true;
+        options.Cookie.IsEssential = true;
+    });
+
+    // ------------------------------
     // Authorization
     // ------------------------------
     // Fallback policy: if an endpoint doesn't explicitly allow anonymous access,
@@ -103,6 +115,8 @@ try
     app.UseHttpsRedirection();
     app.UseStaticFiles(); // Serves wwwroot assets (CSS/JS/images)
     app.UseRouting();
+
+    app.UseSession();
 
     // AuthN first, then AuthZ.
     app.UseAuthentication();

--- a/A New Hope/Views/Home/Index.cshtml
+++ b/A New Hope/Views/Home/Index.cshtml
@@ -1,6 +1,5 @@
 ﻿@{
     ViewData["Title"] = "Home";
-    var users = ViewBag.Users as IEnumerable<dynamic>;
 }
 
 <style>
@@ -29,6 +28,31 @@
         border: 1px solid #343a40;
     }
 
+    .workflow-card {
+        background-color: #f8f9fa !important;
+        border: 2px solid #ced4da;
+        border-radius: 12px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+        height: 100%;
+    }
+
+        .workflow-card .card-body {
+            display: flex;
+            flex-direction: column;
+        }
+
+    .workflow-title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: #343a40;
+        margin-bottom: 10px;
+    }
+
+    .workflow-text {
+        color: #495057;
+        flex-grow: 1;
+    }
+
     .neutral-btn-primary {
         background-color: #343a40 !important;
         border: 2px solid #212529 !important;
@@ -38,6 +62,7 @@
 
         .neutral-btn-primary:hover {
             background-color: #495057 !important;
+            color: white !important;
         }
 
     .neutral-btn-secondary {
@@ -51,132 +76,61 @@
             background-color: #868e96 !important;
             color: white !important;
         }
-
-    .scroll-box {
-        max-height: 450px;
-        overflow-y: auto;
-        background-color: #f8f9fa !important;
-        border-radius: 6px;
-        padding: 10px;
-        border: 2px solid #ced4da;
-    }
-
-    table thead {
-        background-color: #6c757d !important;
-        color: white !important;
-    }
-
-    table {
-        background-color: #ffffff !important;
-        border: 2px solid #ced4da !important;
-    }
-
-        table th, table td {
-            border: 1px solid #adb5bd !important;
-            padding: 8px;
-        }
-
-    .clickable-row:hover {
-        background-color: #dee2e6 !important;
-        cursor: pointer;
-    }
-
-    #searchInput {
-        background-color: #ffffff !important;
-        border: 2px solid #ced4da !important;
-        padding: 10px;
-    }
 </style>
 
 <div class="container mt-5">
     <div class="main-card">
+        <div class="section-header">Workflow Menu</div>
 
-        <div class="d-flex justify-content-between mb-4">
-            <a asp-controller="Referrals" asp-action="Create"
-               class="btn neutral-btn-primary btn-lg w-50 me-2">
-                + New Referral
-            </a>
-            <button class="btn neutral-btn-secondary btn-lg w-50 ms-2" disabled>
-                Reporting (W.I.P.)
-            </button>
+        <p class="mb-4">
+            Select a workflow below. Additional workflows and actions can be added here as the project grows.
+        </p>
+
+        <div class="row g-4">
+            <div class="col-md-6 col-lg-4">
+                <div class="card workflow-card">
+                    <div class="card-body">
+                        <div class="workflow-title">Referral Wizard</div>
+                        <p class="workflow-text">
+                            Start a new referral workflow by selecting an existing referring organization
+                            or entering a new one.
+                        </p>
+                        <a asp-controller="Referrals"
+                           asp-action="WizardStep1"
+                           class="btn neutral-btn-primary mt-auto">
+                            Start Referral Wizard
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card workflow-card">
+                    <div class="card-body">
+                        <div class="workflow-title">Client Wizard</div>
+                        <p class="workflow-text">
+                            Create or locate a client record and guide the user through client-specific entry steps.
+                        </p>
+                        <button class="btn neutral-btn-secondary mt-auto" disabled>
+                            Coming Soon
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card workflow-card">
+                    <div class="card-body">
+                        <div class="workflow-title">Referral Details Wizard</div>
+                        <p class="workflow-text">
+                            Complete referral-specific details such as dates, status, notes, and related follow-up information.
+                        </p>
+                        <button class="btn neutral-btn-secondary mt-auto" disabled>
+                            Coming Soon
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        <div class="section-header mb-3">Client List</div>
-
-        <input type="text" id="searchInput"
-               class="form-control form-control-lg mb-3"
-               placeholder="Search by name, email, or address..." />
-
-        <div class="scroll-box">
-            <table class="table table-hover table-bordered mb-0">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Email</th>
-                        <th>Address</th>
-                    </tr>
-                </thead>
-                <tbody id="resultsBody">
-                    @if (users != null)
-                    {
-                        foreach (var user in users)
-                        {
-                            <tr class="clickable-row" data-id="@user.Id">
-                                <td>@user.FullName</td>
-                                <td>@user.Email</td>
-                                <td>@user.Address</td>
-                            </tr>
-                        }
-                    }
-                </tbody>
-            </table>
-        </div>
-
     </div>
 </div>
-
-@section Scripts {
-    <script>
-        const input = document.getElementById("searchInput");
-        const resultsBody = document.getElementById("resultsBody");
-
-        input.addEventListener("input", function () {
-            const query = input.value;
-
-            if (query.length === 0) {
-                fetch(`/Home/Index`).then(() => location.reload());
-                return;
-            }
-
-            fetch(`/Home/Search?query=${encodeURIComponent(query)}`)
-                .then(r => r.json())
-                .then(data => {
-                    resultsBody.innerHTML = "";
-
-                    if (data.length === 0) {
-                        resultsBody.innerHTML =
-                            `<tr><td colspan="3" class="text-center">No results found</td></tr>`;
-                        return;
-                    }
-
-                    data.forEach(user => {
-                        resultsBody.innerHTML += `
-                            <tr class="clickable-row" data-id="${user.id}">
-                                <td>${user.fullName}</td>
-                                <td>${user.email}</td>
-                                <td>${user.address}</td>
-                            </tr>`;
-                    });
-                });
-        });
-
-        document.addEventListener("click", function (e) {
-            const row = e.target.closest(".clickable-row");
-
-            if (row) {
-                const id = row.getAttribute("data-id");
-                window.location.href = `/ClientProfiles/Details/${id}`;
-            }
-        });
-    </script>
-}

--- a/A New Hope/Views/Referrals/WizardStep1.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep1.cshtml
@@ -1,0 +1,304 @@
+﻿@model A_New_Hope.Models.ViewModels.ReferralWizardStep1ViewModel
+
+@{
+    ViewData["Title"] = "New Referral - Step 1";
+
+    var expandNewOrganization =
+        Model.HasStartedNewOrganization ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewOrganizationName)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewOrganizationType)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewPrimaryContactName)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewEmail)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewPhoneNumber)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewAddressLine1)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewAddressLine2)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewCity)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewState)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewPostalCode)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewNotes));
+
+    var collapseCssClass = expandNewOrganization ? "collapse show" : "collapse";
+}
+
+<div class="container py-4">
+    <h1 class="mb-2">New Referral</h1>
+    <p class="text-muted mb-4">Step 1 of 3: Select an existing organization or add a new one.</p>
+
+    @if (TempData["SuccessMessage"] != null)
+    {
+        <div class="alert alert-success">
+            @TempData["SuccessMessage"]
+        </div>
+    }
+
+    <form asp-action="WizardStep1" method="post" novalidate>
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="row">
+            <div class="col-12">
+                <div class="card shadow-sm wizard-card mb-3" id="existingOrganizationCard">
+                    <div class="card-header bg-white">
+                        <h4 class="mb-0">Select Existing Organization</h4>
+                    </div>
+
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label asp-for="SelectedReferringOrganizationId" class="form-label"></label>
+                            <select asp-for="SelectedReferringOrganizationId"
+                                    asp-items="Model.ExistingOrganizations"
+                                    class="form-select"
+                                    id="selectedOrganization">
+                                <option value="">-- Select an organization --</option>
+                            </select>
+                            <span asp-validation-for="SelectedReferringOrganizationId" class="text-danger"></span>
+                        </div>
+
+                        <p class="text-muted mb-0">
+                            Use this option when the referring organization already exists in the system.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="wizard-divider">
+                    <span>OR</span>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card shadow-sm wizard-card" id="newOrganizationCard">
+                    <div class="card-header bg-white">
+                        <h4 class="mb-0">Add New Organization</h4>
+                    </div>
+
+                    <div class="card-body">
+                        <p class="text-muted">
+                            Use this option when the referring organization is not already in the system.
+                        </p>
+
+                        <button class="btn btn-outline-secondary mb-3"
+                                type="button"
+                                id="toggleNewOrganizationBtn"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#newOrganizationCollapse"
+                                aria-expanded="@(expandNewOrganization.ToString().ToLower())"
+                                aria-controls="newOrganizationCollapse">
+                            + Enter New Organization
+                        </button>
+
+                        <div id="newOrganizationCollapse" class="@collapseCssClass">
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewOrganizationName" class="form-label"></label>
+                                    <input asp-for="NewOrganizationName" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewOrganizationName" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewOrganizationType" class="form-label"></label>
+                                    <input asp-for="NewOrganizationType" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewOrganizationType" class="text-danger"></span>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewPrimaryContactName" class="form-label"></label>
+                                    <input asp-for="NewPrimaryContactName" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewPrimaryContactName" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewEmail" class="form-label"></label>
+                                    <input asp-for="NewEmail" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewEmail" class="text-danger"></span>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewPhoneNumber" class="form-label"></label>
+                                    <input asp-for="NewPhoneNumber" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewPhoneNumber" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewAddressLine1" class="form-label"></label>
+                                    <input asp-for="NewAddressLine1" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewAddressLine1" class="text-danger"></span>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label asp-for="NewAddressLine2" class="form-label"></label>
+                                    <input asp-for="NewAddressLine2" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewAddressLine2" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-4 mb-3">
+                                    <label asp-for="NewCity" class="form-label"></label>
+                                    <input asp-for="NewCity" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewCity" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-2 mb-3">
+                                    <label asp-for="NewState" class="form-label"></label>
+                                    <input asp-for="NewState" class="form-control text-uppercase new-org-input" maxlength="2" />
+                                    <span asp-validation-for="NewState" class="text-danger"></span>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-4 mb-3">
+                                    <label asp-for="NewPostalCode" class="form-label"></label>
+                                    <input asp-for="NewPostalCode" class="form-control new-org-input" />
+                                    <span asp-validation-for="NewPostalCode" class="text-danger"></span>
+                                </div>
+
+                                <div class="col-md-8 mb-3">
+                                    <label asp-for="NewNotes" class="form-label"></label>
+                                    <textarea asp-for="NewNotes" class="form-control new-org-input" rows="3"></textarea>
+                                    <span asp-validation-for="NewNotes" class="text-danger"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="d-flex justify-content-end gap-2 mt-4">
+            <a asp-controller="Home" asp-action="Index" class="btn btn-outline-secondary">Back</a>
+            <button type="submit" class="btn btn-primary">Next</button>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const selectedOrganization = document.getElementById("selectedOrganization");
+            const existingOrganizationCard = document.getElementById("existingOrganizationCard");
+            const newOrganizationCard = document.getElementById("newOrganizationCard");
+            const toggleButton = document.getElementById("toggleNewOrganizationBtn");
+            const newOrgInputs = document.querySelectorAll(".new-org-input");
+            const collapseElement = document.getElementById("newOrganizationCollapse");
+            const collapseInstance = bootstrap.Collapse.getOrCreateInstance(collapseElement, { toggle: false });
+
+            function hasNewOrganizationInput() {
+                for (const input of newOrgInputs) {
+                    if (input.value && input.value.trim() !== "") {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            function setExistingOrganizationDisabled(isDisabled) {
+                selectedOrganization.disabled = isDisabled;
+
+                if (isDisabled) {
+                    existingOrganizationCard.classList.add("disabled-card");
+                } else {
+                    existingOrganizationCard.classList.remove("disabled-card");
+                }
+            }
+
+            function setNewOrganizationDisabled(isDisabled) {
+                if (isDisabled) {
+                    newOrganizationCard.classList.add("disabled-card");
+                    toggleButton.disabled = true;
+
+                    newOrgInputs.forEach(input => {
+                        input.disabled = true;
+                    });
+
+                    collapseInstance.hide();
+                } else {
+                    newOrganizationCard.classList.remove("disabled-card");
+                    toggleButton.disabled = false;
+
+                    newOrgInputs.forEach(input => {
+                        input.disabled = false;
+                    });
+                }
+            }
+
+            function updateWizardState() {
+                const hasExistingSelection = selectedOrganization.value !== "";
+                const hasNewInput = hasNewOrganizationInput();
+
+                if (hasExistingSelection) {
+                    setNewOrganizationDisabled(true);
+                    setExistingOrganizationDisabled(false);
+                    return;
+                }
+
+                if (hasNewInput) {
+                    setExistingOrganizationDisabled(true);
+                    setNewOrganizationDisabled(false);
+                    return;
+                }
+
+                setExistingOrganizationDisabled(false);
+                setNewOrganizationDisabled(false);
+            }
+
+            selectedOrganization.addEventListener("change", updateWizardState);
+
+            newOrgInputs.forEach(input => {
+                input.addEventListener("input", updateWizardState);
+                input.addEventListener("change", updateWizardState);
+            });
+
+            updateWizardState();
+        });
+    </script>
+}
+
+<style>
+    .wizard-card {
+        border-radius: 12px;
+        border: 1px solid #d9dee3;
+    }
+
+        .wizard-card .card-header {
+            border-bottom: 1px solid #e9ecef;
+        }
+
+    .wizard-divider {
+        display: flex;
+        align-items: center;
+        text-align: center;
+        margin: 0.5rem 0 1.25rem 0;
+    }
+
+        .wizard-divider::before,
+        .wizard-divider::after {
+            content: "";
+            flex: 1;
+            border-bottom: 1px solid #ced4da;
+        }
+
+        .wizard-divider span {
+            padding: 0 1rem;
+            font-weight: 600;
+            color: #6c757d;
+            letter-spacing: 0.05em;
+        }
+
+    .disabled-card {
+        opacity: 0.6;
+    }
+
+        .disabled-card .card-header,
+        .disabled-card .card-body {
+            background-color: #f8f9fa;
+        }
+</style>

--- a/A New Hope/Views/Referrals/WizardStep1.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep1.cshtml
@@ -43,7 +43,7 @@
 
 <div class="container py-4">
     <h1 class="mb-2">New Referral</h1>
-    <p class="text-muted mb-4">Step 1 of 3: Select or add the referring organization and client.</p>
+    <p class="text-muted mb-4">Step 1 of 3: Select or add the referring organization, client, and referral details.</p>
 
     @if (TempData["SuccessMessage"] != null)
     {
@@ -196,7 +196,7 @@
         </div>
 
         <!-- Client Section -->
-        <div class="mb-4">
+        <div class="mb-5">
             <h3 class="mb-3">Client</h3>
 
             <div class="row">
@@ -351,7 +351,6 @@
                                 </div>
 
                                 <hr />
-                                <hr />
                                 <button class="btn btn-outline-secondary mb-3"
                                         type="button"
                                         id="toggleHouseholdMembersBtn"
@@ -460,6 +459,82 @@
             </div>
         </div>
 
+        <!-- Referral Details Section -->
+        <div class="mb-4">
+            <h3 class="mb-3">Referral Details</h3>
+
+            <div class="card shadow-sm wizard-card">
+                <div class="card-header bg-white">
+                    <h4 class="mb-0">Referral Information</h4>
+                </div>
+
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label asp-for="ReferredOn" class="form-label"></label>
+                            <input asp-for="ReferredOn" class="form-control" type="date" />
+                            <span asp-validation-for="ReferredOn" class="text-danger"></span>
+                        </div>
+
+                        <div class="col-md-4 mb-3">
+                            <label asp-for="Status" class="form-label"></label>
+                            <select asp-for="Status"
+                                    asp-items="Model.ReferralStatusOptions"
+                                    class="form-select">
+                                <option value="">-- Select status --</option>
+                            </select>
+                            <span asp-validation-for="Status" class="text-danger"></span>
+                        </div>
+
+                        <div class="col-md-4 mb-3"></div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label asp-for="ValidFrom" class="form-label"></label>
+                            <input asp-for="ValidFrom" class="form-control" type="date" />
+                            <span asp-validation-for="ValidFrom" class="text-danger"></span>
+                        </div>
+
+                        <div class="col-md-6 mb-3">
+                            <label asp-for="ValidTo" class="form-label"></label>
+                            <input asp-for="ValidTo" class="form-control" type="date" />
+                            <span asp-validation-for="ValidTo" class="text-danger"></span>
+                        </div>
+                    </div>
+
+                    <hr />
+                    <h5 class="mb-3">Referrer Contact</h5>
+
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label asp-for="ReferredByName" class="form-label"></label>
+                            <input asp-for="ReferredByName" class="form-control" />
+                            <span asp-validation-for="ReferredByName" class="text-danger"></span>
+                        </div>
+
+                        <div class="col-md-4 mb-3">
+                            <label asp-for="ReferredByPhoneNumber" class="form-label"></label>
+                            <input asp-for="ReferredByPhoneNumber" class="form-control" />
+                            <span asp-validation-for="ReferredByPhoneNumber" class="text-danger"></span>
+                        </div>
+
+                        <div class="col-md-4 mb-3">
+                            <label asp-for="ReferredByEmail" class="form-label"></label>
+                            <input asp-for="ReferredByEmail" class="form-control" />
+                            <span asp-validation-for="ReferredByEmail" class="text-danger"></span>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label asp-for="ReferralNotes" class="form-label"></label>
+                        <textarea asp-for="ReferralNotes" class="form-control" rows="4"></textarea>
+                        <span asp-validation-for="ReferralNotes" class="text-danger"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="d-flex justify-content-end gap-2 mt-4">
             <a asp-controller="Home" asp-action="Index" class="btn btn-outline-secondary">Back</a>
             <button type="submit" class="btn btn-primary">Next</button>
@@ -537,7 +612,6 @@
                 input.addEventListener("input", updateOrganizationState);
                 input.addEventListener("change", updateOrganizationState);
             });
-
 
             // Client section
             const selectedClient = document.getElementById("selectedClient");

--- a/A New Hope/Views/Referrals/WizardStep1.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep1.cshtml
@@ -538,6 +538,7 @@
                 input.addEventListener("change", updateOrganizationState);
             });
 
+
             // Client section
             const selectedClient = document.getElementById("selectedClient");
             const existingClientCard = document.getElementById("existingClientCard");
@@ -545,13 +546,15 @@
             const toggleClientButton = document.getElementById("toggleNewClientBtn");
             const clientCollapseElement = document.getElementById("newClientCollapse");
             const clientCollapseInstance = bootstrap.Collapse.getOrCreateInstance(clientCollapseElement, { toggle: false });
+
             const householdCollapseElement = document.getElementById("householdMembersCollapse");
-            const householdCollapseInstance = bootstrap.Collapse.getOrCreateInstance(householdCollapseElement, { toggle: false });
+            const householdCollapseInstance = householdCollapseElement
+                ? bootstrap.Collapse.getOrCreateInstance(householdCollapseElement, { toggle: false })
+                : null;
+
             const householdMembersContainer = document.getElementById("householdMembersContainer");
             const householdTemplate = document.getElementById("householdMemberTemplate");
             const addHouseholdMemberBtn = document.getElementById("addHouseholdMemberBtn");
-            const householdCollapseElement = document.getElementById("householdMembersCollapse");
-            const householdCollapseInstance = bootstrap.Collapse.getOrCreateInstance(householdCollapseElement, { toggle: false });
 
             function getNewClientInputs() {
                 return document.querySelectorAll(".new-client-input");
@@ -562,11 +565,14 @@
 
                 for (const input of inputs) {
                     if (input.type === "checkbox") {
-                        if (input.checked) return true;
+                        if (input.checked) {
+                            return true;
+                        }
                     } else if (input.value && input.value.trim() !== "") {
                         return true;
                     }
                 }
+
                 return false;
             }
 
@@ -577,8 +583,14 @@
 
             function setNewClientDisabled(isDisabled) {
                 newClientCard.classList.toggle("disabled-card", isDisabled);
-                toggleClientButton.disabled = isDisabled;
-                addHouseholdMemberBtn.disabled = isDisabled;
+
+                if (toggleClientButton) {
+                    toggleClientButton.disabled = isDisabled;
+                }
+
+                if (addHouseholdMemberBtn) {
+                    addHouseholdMemberBtn.disabled = isDisabled;
+                }
 
                 getNewClientInputs().forEach(input => {
                     input.disabled = isDisabled;
@@ -589,7 +601,10 @@
                 });
 
                 if (isDisabled) {
-                    householdCollapseInstance.hide();
+                    if (householdCollapseInstance) {
+                        householdCollapseInstance.hide();
+                    }
+
                     clientCollapseInstance.hide();
                 }
             }
@@ -613,31 +628,50 @@
                 setNewClientDisabled(false);
             }
 
-            function rebindRemoveButtons() {
-                document.querySelectorAll(".removeHouseholdMemberBtn").forEach(button => {
-                    button.onclick = function () {
-                        const items = householdMembersContainer.querySelectorAll(".household-member-item");
+            if (addHouseholdMemberBtn && householdMembersContainer && householdTemplate) {
+                addHouseholdMemberBtn.addEventListener("click", function () {
+                    const index = householdMembersContainer.querySelectorAll(".household-member-item").length;
+                    const html = householdTemplate.innerHTML.replaceAll("__index__", index);
 
-                        if (items.length > 1) {
-                            button.closest(".household-member-item").remove();
-                            updateClientState();
-                        } else {
-                            const parent = button.closest(".household-member-item");
-                            parent.querySelectorAll("input").forEach(input => input.value = "");
-                            updateClientState();
-                        }
-                    };
+                    householdMembersContainer.insertAdjacentHTML("beforeend", html);
+
+                    if (householdCollapseInstance) {
+                        householdCollapseInstance.show();
+                    }
+
+                    updateClientState();
                 });
             }
 
-            addHouseholdMemberBtn.addEventListener("click", function () {
-                const index = householdMembersContainer.querySelectorAll(".household-member-item").length;
-                const html = householdTemplate.innerHTML.replaceAll("__index__", index);
-                householdMembersContainer.insertAdjacentHTML("beforeend", html);
-                householdCollapseInstance.show();
-                rebindRemoveButtons();
-                updateClientState();
-            });
+            if (householdMembersContainer) {
+                householdMembersContainer.addEventListener("click", function (e) {
+                    const removeButton = e.target.closest(".removeHouseholdMemberBtn");
+                    if (!removeButton) {
+                        return;
+                    }
+
+                    const card = removeButton.closest(".household-member-item");
+                    if (!card) {
+                        return;
+                    }
+
+                    const items = householdMembersContainer.querySelectorAll(".household-member-item");
+
+                    if (items.length > 1) {
+                        card.remove();
+                    } else {
+                        card.querySelectorAll("input").forEach(input => {
+                            if (input.type === "checkbox" || input.type === "radio") {
+                                input.checked = false;
+                            } else {
+                                input.value = "";
+                            }
+                        });
+                    }
+
+                    updateClientState();
+                });
+            }
 
             selectedClient.addEventListener("change", updateClientState);
 
@@ -653,7 +687,6 @@
                 }
             });
 
-            rebindRemoveButtons();
             updateOrganizationState();
             updateClientState();
         });

--- a/A New Hope/Views/Referrals/WizardStep1.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep1.cshtml
@@ -35,6 +35,10 @@
 
     var organizationCollapseCssClass = expandNewOrganization ? "collapse show" : "collapse";
     var clientCollapseCssClass = expandNewClient ? "collapse show" : "collapse";
+    var expandHouseholdMembers =
+        (Model.HouseholdMembers?.Any(h => h.HasStarted) ?? false) ||
+        ViewData.ModelState.Keys.Any(k => k.StartsWith("HouseholdMembers["));
+    var householdCollapseCssClass = expandHouseholdMembers ? "collapse show" : "collapse";
 }
 
 <div class="container py-4">
@@ -347,50 +351,63 @@
                                 </div>
 
                                 <hr />
-                                <div class="d-flex justify-content-between align-items-center mb-3">
-                                    <h5 class="mb-0">Household Members</h5>
-                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="addHouseholdMemberBtn">
-                                        + Add Household Member
-                                    </button>
-                                </div>
+                                <hr />
+                                <button class="btn btn-outline-secondary mb-3"
+                                        type="button"
+                                        id="toggleHouseholdMembersBtn"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#householdMembersCollapse"
+                                        aria-expanded="@(expandHouseholdMembers.ToString().ToLower())"
+                                        aria-controls="householdMembersCollapse">
+                                    + Add Household Members
+                                </button>
 
-                                <div id="householdMembersContainer">
-                                    @for (int i = 0; i < Model.HouseholdMembers.Count; i++)
-                                    {
-                                        <div class="card border-0 bg-light mb-3 household-member-item">
-                                            <div class="card-body">
-                                                <div class="row">
-                                                    <div class="col-md-6 mb-3">
-                                                        <label asp-for="HouseholdMembers[i].FirstName" class="form-label"></label>
-                                                        <input asp-for="HouseholdMembers[i].FirstName" class="form-control household-input new-client-input" />
-                                                        <span asp-validation-for="HouseholdMembers[i].FirstName" class="text-danger"></span>
+                                <div id="householdMembersCollapse" class="@householdCollapseCssClass">
+                                    <div class="d-flex justify-content-between align-items-center mb-3">
+                                        <h5 class="mb-0">Household Members</h5>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="addHouseholdMemberBtn">
+                                            + Add Household Member
+                                        </button>
+                                    </div>
+
+                                    <div id="householdMembersContainer">
+                                        @for (int i = 0; i < Model.HouseholdMembers.Count; i++)
+                                        {
+                                            <div class="card border-0 bg-light mb-3 household-member-item">
+                                                <div class="card-body">
+                                                    <div class="row">
+                                                        <div class="col-md-6 mb-3">
+                                                            <label asp-for="HouseholdMembers[i].FirstName" class="form-label"></label>
+                                                            <input asp-for="HouseholdMembers[i].FirstName" class="form-control household-input new-client-input" />
+                                                            <span asp-validation-for="HouseholdMembers[i].FirstName" class="text-danger"></span>
+                                                        </div>
+
+                                                        <div class="col-md-6 mb-3">
+                                                            <label asp-for="HouseholdMembers[i].LastName" class="form-label"></label>
+                                                            <input asp-for="HouseholdMembers[i].LastName" class="form-control household-input new-client-input" />
+                                                            <span asp-validation-for="HouseholdMembers[i].LastName" class="text-danger"></span>
+                                                        </div>
+
+                                                        <div class="col-md-6 mb-3">
+                                                            <label asp-for="HouseholdMembers[i].DateOfBirth" class="form-label"></label>
+                                                            <input asp-for="HouseholdMembers[i].DateOfBirth" class="form-control household-input new-client-input" type="date" />
+                                                            <span asp-validation-for="HouseholdMembers[i].DateOfBirth" class="text-danger"></span>
+                                                        </div>
+
+                                                        <div class="col-md-6 mb-3">
+                                                            <label asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-label"></label>
+                                                            <input asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-control household-input new-client-input" type="date" />
+                                                            <span asp-validation-for="HouseholdMembers[i].AgeAsOfDate" class="text-danger"></span>
+                                                        </div>
                                                     </div>
 
-                                                    <div class="col-md-6 mb-3">
-                                                        <label asp-for="HouseholdMembers[i].LastName" class="form-label"></label>
-                                                        <input asp-for="HouseholdMembers[i].LastName" class="form-control household-input new-client-input" />
-                                                        <span asp-validation-for="HouseholdMembers[i].LastName" class="text-danger"></span>
-                                                    </div>
-
-                                                    <div class="col-md-6 mb-3">
-                                                        <label asp-for="HouseholdMembers[i].DateOfBirth" class="form-label"></label>
-                                                        <input asp-for="HouseholdMembers[i].DateOfBirth" class="form-control household-input new-client-input" type="date" />
-                                                        <span asp-validation-for="HouseholdMembers[i].DateOfBirth" class="text-danger"></span>
-                                                    </div>
-
-                                                    <div class="col-md-6 mb-3">
-                                                        <label asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-label"></label>
-                                                        <input asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-control household-input new-client-input" type="date" />
-                                                        <span asp-validation-for="HouseholdMembers[i].AgeAsOfDate" class="text-danger"></span>
-                                                    </div>
+                                                    <button type="button" class="btn btn-outline-danger btn-sm removeHouseholdMemberBtn">
+                                                        Remove
+                                                    </button>
                                                 </div>
-
-                                                <button type="button" class="btn btn-outline-danger btn-sm removeHouseholdMemberBtn">
-                                                    Remove
-                                                </button>
                                             </div>
-                                        </div>
-                                    }
+                                        }
+                                    </div>
                                 </div>
 
                                 <template id="householdMemberTemplate">
@@ -528,9 +545,13 @@
             const toggleClientButton = document.getElementById("toggleNewClientBtn");
             const clientCollapseElement = document.getElementById("newClientCollapse");
             const clientCollapseInstance = bootstrap.Collapse.getOrCreateInstance(clientCollapseElement, { toggle: false });
+            const householdCollapseElement = document.getElementById("householdMembersCollapse");
+            const householdCollapseInstance = bootstrap.Collapse.getOrCreateInstance(householdCollapseElement, { toggle: false });
             const householdMembersContainer = document.getElementById("householdMembersContainer");
             const householdTemplate = document.getElementById("householdMemberTemplate");
             const addHouseholdMemberBtn = document.getElementById("addHouseholdMemberBtn");
+            const householdCollapseElement = document.getElementById("householdMembersCollapse");
+            const householdCollapseInstance = bootstrap.Collapse.getOrCreateInstance(householdCollapseElement, { toggle: false });
 
             function getNewClientInputs() {
                 return document.querySelectorAll(".new-client-input");
@@ -568,6 +589,7 @@
                 });
 
                 if (isDisabled) {
+                    householdCollapseInstance.hide();
                     clientCollapseInstance.hide();
                 }
             }
@@ -612,6 +634,7 @@
                 const index = householdMembersContainer.querySelectorAll(".household-member-item").length;
                 const html = householdTemplate.innerHTML.replaceAll("__index__", index);
                 householdMembersContainer.insertAdjacentHTML("beforeend", html);
+                householdCollapseInstance.show();
                 rebindRemoveButtons();
                 updateClientState();
             });

--- a/A New Hope/Views/Referrals/WizardStep1.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep1.cshtml
@@ -17,12 +17,29 @@
         ViewData.ModelState.ContainsKey(nameof(Model.NewPostalCode)) ||
         ViewData.ModelState.ContainsKey(nameof(Model.NewNotes));
 
-    var collapseCssClass = expandNewOrganization ? "collapse show" : "collapse";
+    var expandNewClient =
+        Model.HasStartedNewClient ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientFirstName)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientLastName)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientEmail)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientPhoneNumber)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientAddressLine1)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientAddressLine2)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientCity)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientState)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientPostalCode)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientDateOfBirth)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientEmploymentStatus)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientEarnedIncomeMonthly)) ||
+        ViewData.ModelState.ContainsKey(nameof(Model.NewClientIsUnhoused));
+
+    var organizationCollapseCssClass = expandNewOrganization ? "collapse show" : "collapse";
+    var clientCollapseCssClass = expandNewClient ? "collapse show" : "collapse";
 }
 
 <div class="container py-4">
     <h1 class="mb-2">New Referral</h1>
-    <p class="text-muted mb-4">Step 1 of 3: Select an existing organization or add a new one.</p>
+    <p class="text-muted mb-4">Step 1 of 3: Select or add the referring organization and client.</p>
 
     @if (TempData["SuccessMessage"] != null)
     {
@@ -34,134 +51,391 @@
     <form asp-action="WizardStep1" method="post" novalidate>
         <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
-        <div class="row">
-            <div class="col-12">
-                <div class="card shadow-sm wizard-card mb-3" id="existingOrganizationCard">
-                    <div class="card-header bg-white">
-                        <h4 class="mb-0">Select Existing Organization</h4>
-                    </div>
+        <!-- Referring Organization Section -->
+        <div class="mb-5">
+            <h3 class="mb-3">Referring Organization</h3>
 
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <label asp-for="SelectedReferringOrganizationId" class="form-label"></label>
-                            <select asp-for="SelectedReferringOrganizationId"
-                                    asp-items="Model.ExistingOrganizations"
-                                    class="form-select"
-                                    id="selectedOrganization">
-                                <option value="">-- Select an organization --</option>
-                            </select>
-                            <span asp-validation-for="SelectedReferringOrganizationId" class="text-danger"></span>
+            <div class="row">
+                <div class="col-12">
+                    <div class="card shadow-sm wizard-card mb-3" id="existingOrganizationCard">
+                        <div class="card-header bg-white">
+                            <h4 class="mb-0">Select Existing Organization</h4>
                         </div>
 
-                        <p class="text-muted mb-0">
-                            Use this option when the referring organization already exists in the system.
-                        </p>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label asp-for="SelectedReferringOrganizationId" class="form-label"></label>
+                                <select asp-for="SelectedReferringOrganizationId"
+                                        asp-items="Model.ExistingOrganizations"
+                                        class="form-select"
+                                        id="selectedOrganization">
+                                    <option value="">-- Select an organization --</option>
+                                </select>
+                                <span asp-validation-for="SelectedReferringOrganizationId" class="text-danger"></span>
+                            </div>
+
+                            <p class="text-muted mb-0">
+                                Use this option when the referring organization already exists in the system.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12">
+                    <div class="wizard-divider">
+                        <span>OR</span>
+                    </div>
+                </div>
+
+                <div class="col-12">
+                    <div class="card shadow-sm wizard-card" id="newOrganizationCard">
+                        <div class="card-header bg-white">
+                            <h4 class="mb-0">Add New Organization</h4>
+                        </div>
+
+                        <div class="card-body">
+                            <p class="text-muted">
+                                Use this option when the referring organization is not already in the system.
+                            </p>
+
+                            <button class="btn btn-outline-secondary mb-3"
+                                    type="button"
+                                    id="toggleNewOrganizationBtn"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#newOrganizationCollapse"
+                                    aria-expanded="@(expandNewOrganization.ToString().ToLower())"
+                                    aria-controls="newOrganizationCollapse">
+                                + Enter New Organization
+                            </button>
+
+                            <div id="newOrganizationCollapse" class="@organizationCollapseCssClass">
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewOrganizationName" class="form-label"></label>
+                                        <input asp-for="NewOrganizationName" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewOrganizationName" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewOrganizationType" class="form-label"></label>
+                                        <input asp-for="NewOrganizationType" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewOrganizationType" class="text-danger"></span>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewPrimaryContactName" class="form-label"></label>
+                                        <input asp-for="NewPrimaryContactName" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewPrimaryContactName" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewEmail" class="form-label"></label>
+                                        <input asp-for="NewEmail" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewEmail" class="text-danger"></span>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewPhoneNumber" class="form-label"></label>
+                                        <input asp-for="NewPhoneNumber" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewPhoneNumber" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewAddressLine1" class="form-label"></label>
+                                        <input asp-for="NewAddressLine1" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewAddressLine1" class="text-danger"></span>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewAddressLine2" class="form-label"></label>
+                                        <input asp-for="NewAddressLine2" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewAddressLine2" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-4 mb-3">
+                                        <label asp-for="NewCity" class="form-label"></label>
+                                        <input asp-for="NewCity" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewCity" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-2 mb-3">
+                                        <label asp-for="NewState" class="form-label"></label>
+                                        <input asp-for="NewState" class="form-control text-uppercase new-org-input" maxlength="2" />
+                                        <span asp-validation-for="NewState" class="text-danger"></span>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-4 mb-3">
+                                        <label asp-for="NewPostalCode" class="form-label"></label>
+                                        <input asp-for="NewPostalCode" class="form-control new-org-input" />
+                                        <span asp-validation-for="NewPostalCode" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-8 mb-3">
+                                        <label asp-for="NewNotes" class="form-label"></label>
+                                        <textarea asp-for="NewNotes" class="form-control new-org-input" rows="3"></textarea>
+                                        <span asp-validation-for="NewNotes" class="text-danger"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
+        </div>
 
-            <div class="col-12">
-                <div class="wizard-divider">
-                    <span>OR</span>
-                </div>
-            </div>
+        <!-- Client Section -->
+        <div class="mb-4">
+            <h3 class="mb-3">Client</h3>
 
-            <div class="col-12">
-                <div class="card shadow-sm wizard-card" id="newOrganizationCard">
-                    <div class="card-header bg-white">
-                        <h4 class="mb-0">Add New Organization</h4>
+            <div class="row">
+                <div class="col-12">
+                    <div class="card shadow-sm wizard-card mb-3" id="existingClientCard">
+                        <div class="card-header bg-white">
+                            <h4 class="mb-0">Select Existing Client</h4>
+                        </div>
+
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label asp-for="SelectedClientUserId" class="form-label"></label>
+                                <select asp-for="SelectedClientUserId"
+                                        asp-items="Model.ExistingClients"
+                                        class="form-select"
+                                        id="selectedClient">
+                                    <option value="">-- Select a client --</option>
+                                </select>
+                                <span asp-validation-for="SelectedClientUserId" class="text-danger"></span>
+                            </div>
+
+                            <p class="text-muted mb-0">
+                                Use this option when the client already exists in the system.
+                            </p>
+                        </div>
                     </div>
+                </div>
 
-                    <div class="card-body">
-                        <p class="text-muted">
-                            Use this option when the referring organization is not already in the system.
-                        </p>
+                <div class="col-12">
+                    <div class="wizard-divider">
+                        <span>OR</span>
+                    </div>
+                </div>
 
-                        <button class="btn btn-outline-secondary mb-3"
-                                type="button"
-                                id="toggleNewOrganizationBtn"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#newOrganizationCollapse"
-                                aria-expanded="@(expandNewOrganization.ToString().ToLower())"
-                                aria-controls="newOrganizationCollapse">
-                            + Enter New Organization
-                        </button>
+                <div class="col-12">
+                    <div class="card shadow-sm wizard-card" id="newClientCard">
+                        <div class="card-header bg-white">
+                            <h4 class="mb-0">Add New Client</h4>
+                        </div>
 
-                        <div id="newOrganizationCollapse" class="@collapseCssClass">
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewOrganizationName" class="form-label"></label>
-                                    <input asp-for="NewOrganizationName" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewOrganizationName" class="text-danger"></span>
+                        <div class="card-body">
+                            <p class="text-muted">
+                                Use this option when the client is not already in the system.
+                            </p>
+
+                            <button class="btn btn-outline-secondary mb-3"
+                                    type="button"
+                                    id="toggleNewClientBtn"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#newClientCollapse"
+                                    aria-expanded="@(expandNewClient.ToString().ToLower())"
+                                    aria-controls="newClientCollapse">
+                                + Enter New Client
+                            </button>
+
+                            <div id="newClientCollapse" class="@clientCollapseCssClass">
+                                <!-- Core Client Fields -->
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientFirstName" class="form-label"></label>
+                                        <input asp-for="NewClientFirstName" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientFirstName" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientLastName" class="form-label"></label>
+                                        <input asp-for="NewClientLastName" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientLastName" class="text-danger"></span>
+                                    </div>
                                 </div>
 
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewOrganizationType" class="form-label"></label>
-                                    <input asp-for="NewOrganizationType" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewOrganizationType" class="text-danger"></span>
-                                </div>
-                            </div>
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientEmail" class="form-label"></label>
+                                        <input asp-for="NewClientEmail" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientEmail" class="text-danger"></span>
+                                    </div>
 
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewPrimaryContactName" class="form-label"></label>
-                                    <input asp-for="NewPrimaryContactName" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewPrimaryContactName" class="text-danger"></span>
-                                </div>
-
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewEmail" class="form-label"></label>
-                                    <input asp-for="NewEmail" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewEmail" class="text-danger"></span>
-                                </div>
-                            </div>
-
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewPhoneNumber" class="form-label"></label>
-                                    <input asp-for="NewPhoneNumber" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewPhoneNumber" class="text-danger"></span>
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientPhoneNumber" class="form-label"></label>
+                                        <input asp-for="NewClientPhoneNumber" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientPhoneNumber" class="text-danger"></span>
+                                    </div>
                                 </div>
 
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewAddressLine1" class="form-label"></label>
-                                    <input asp-for="NewAddressLine1" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewAddressLine1" class="text-danger"></span>
-                                </div>
-                            </div>
-
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label asp-for="NewAddressLine2" class="form-label"></label>
-                                    <input asp-for="NewAddressLine2" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewAddressLine2" class="text-danger"></span>
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientDateOfBirth" class="form-label"></label>
+                                        <input asp-for="NewClientDateOfBirth" class="form-control new-client-input" type="date" />
+                                        <span asp-validation-for="NewClientDateOfBirth" class="text-danger"></span>
+                                    </div>
                                 </div>
 
-                                <div class="col-md-4 mb-3">
-                                    <label asp-for="NewCity" class="form-label"></label>
-                                    <input asp-for="NewCity" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewCity" class="text-danger"></span>
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientAddressLine1" class="form-label"></label>
+                                        <input asp-for="NewClientAddressLine1" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientAddressLine1" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientAddressLine2" class="form-label"></label>
+                                        <input asp-for="NewClientAddressLine2" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientAddressLine2" class="text-danger"></span>
+                                    </div>
                                 </div>
 
-                                <div class="col-md-2 mb-3">
-                                    <label asp-for="NewState" class="form-label"></label>
-                                    <input asp-for="NewState" class="form-control text-uppercase new-org-input" maxlength="2" />
-                                    <span asp-validation-for="NewState" class="text-danger"></span>
-                                </div>
-                            </div>
+                                <div class="row">
+                                    <div class="col-md-4 mb-3">
+                                        <label asp-for="NewClientCity" class="form-label"></label>
+                                        <input asp-for="NewClientCity" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientCity" class="text-danger"></span>
+                                    </div>
 
-                            <div class="row">
-                                <div class="col-md-4 mb-3">
-                                    <label asp-for="NewPostalCode" class="form-label"></label>
-                                    <input asp-for="NewPostalCode" class="form-control new-org-input" />
-                                    <span asp-validation-for="NewPostalCode" class="text-danger"></span>
+                                    <div class="col-md-2 mb-3">
+                                        <label asp-for="NewClientState" class="form-label"></label>
+                                        <input asp-for="NewClientState" class="form-control text-uppercase new-client-input" maxlength="2" />
+                                        <span asp-validation-for="NewClientState" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientPostalCode" class="form-label"></label>
+                                        <input asp-for="NewClientPostalCode" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientPostalCode" class="text-danger"></span>
+                                    </div>
                                 </div>
 
-                                <div class="col-md-8 mb-3">
-                                    <label asp-for="NewNotes" class="form-label"></label>
-                                    <textarea asp-for="NewNotes" class="form-control new-org-input" rows="3"></textarea>
-                                    <span asp-validation-for="NewNotes" class="text-danger"></span>
+                                <hr />
+                                <h5 class="mb-3">Client Profile</h5>
+
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientEmploymentStatus" class="form-label"></label>
+                                        <input asp-for="NewClientEmploymentStatus" class="form-control new-client-input" />
+                                        <span asp-validation-for="NewClientEmploymentStatus" class="text-danger"></span>
+                                    </div>
+
+                                    <div class="col-md-6 mb-3">
+                                        <label asp-for="NewClientEarnedIncomeMonthly" class="form-label"></label>
+                                        <input asp-for="NewClientEarnedIncomeMonthly"
+                                               class="form-control new-client-input"
+                                               type="number"
+                                               step="0.01"
+                                               min="0" />
+                                        <span asp-validation-for="NewClientEarnedIncomeMonthly" class="text-danger"></span>
+                                    </div>
                                 </div>
+
+                                <div class="form-check mb-4">
+                                    <input asp-for="NewClientIsUnhoused" class="form-check-input new-client-input" />
+                                    <label asp-for="NewClientIsUnhoused" class="form-check-label"></label>
+                                </div>
+
+                                <hr />
+                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                    <h5 class="mb-0">Household Members</h5>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="addHouseholdMemberBtn">
+                                        + Add Household Member
+                                    </button>
+                                </div>
+
+                                <div id="householdMembersContainer">
+                                    @for (int i = 0; i < Model.HouseholdMembers.Count; i++)
+                                    {
+                                        <div class="card border-0 bg-light mb-3 household-member-item">
+                                            <div class="card-body">
+                                                <div class="row">
+                                                    <div class="col-md-6 mb-3">
+                                                        <label asp-for="HouseholdMembers[i].FirstName" class="form-label"></label>
+                                                        <input asp-for="HouseholdMembers[i].FirstName" class="form-control household-input new-client-input" />
+                                                        <span asp-validation-for="HouseholdMembers[i].FirstName" class="text-danger"></span>
+                                                    </div>
+
+                                                    <div class="col-md-6 mb-3">
+                                                        <label asp-for="HouseholdMembers[i].LastName" class="form-label"></label>
+                                                        <input asp-for="HouseholdMembers[i].LastName" class="form-control household-input new-client-input" />
+                                                        <span asp-validation-for="HouseholdMembers[i].LastName" class="text-danger"></span>
+                                                    </div>
+
+                                                    <div class="col-md-6 mb-3">
+                                                        <label asp-for="HouseholdMembers[i].DateOfBirth" class="form-label"></label>
+                                                        <input asp-for="HouseholdMembers[i].DateOfBirth" class="form-control household-input new-client-input" type="date" />
+                                                        <span asp-validation-for="HouseholdMembers[i].DateOfBirth" class="text-danger"></span>
+                                                    </div>
+
+                                                    <div class="col-md-6 mb-3">
+                                                        <label asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-label"></label>
+                                                        <input asp-for="HouseholdMembers[i].AgeAsOfDate" class="form-control household-input new-client-input" type="date" />
+                                                        <span asp-validation-for="HouseholdMembers[i].AgeAsOfDate" class="text-danger"></span>
+                                                    </div>
+                                                </div>
+
+                                                <button type="button" class="btn btn-outline-danger btn-sm removeHouseholdMemberBtn">
+                                                    Remove
+                                                </button>
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+
+                                <template id="householdMemberTemplate">
+                                    <div class="card border-0 bg-light mb-3 household-member-item">
+                                        <div class="card-body">
+                                            <div class="row">
+                                                <div class="col-md-6 mb-3">
+                                                    <label class="form-label" for="HouseholdMembers___index___FirstName">First Name</label>
+                                                    <input class="form-control household-input new-client-input"
+                                                           type="text"
+                                                           id="HouseholdMembers___index___FirstName"
+                                                           name="HouseholdMembers[__index__].FirstName" />
+                                                </div>
+
+                                                <div class="col-md-6 mb-3">
+                                                    <label class="form-label" for="HouseholdMembers___index___LastName">Last Name</label>
+                                                    <input class="form-control household-input new-client-input"
+                                                           type="text"
+                                                           id="HouseholdMembers___index___LastName"
+                                                           name="HouseholdMembers[__index__].LastName" />
+                                                </div>
+
+                                                <div class="col-md-6 mb-3">
+                                                    <label class="form-label" for="HouseholdMembers___index___DateOfBirth">Date of Birth</label>
+                                                    <input class="form-control household-input new-client-input"
+                                                           type="date"
+                                                           id="HouseholdMembers___index___DateOfBirth"
+                                                           name="HouseholdMembers[__index__].DateOfBirth" />
+                                                </div>
+
+                                                <div class="col-md-6 mb-3">
+                                                    <label class="form-label" for="HouseholdMembers___index___AgeAsOfDate">Age As Of Date</label>
+                                                    <input class="form-control household-input new-client-input"
+                                                           type="date"
+                                                           id="HouseholdMembers___index___AgeAsOfDate"
+                                                           name="HouseholdMembers[__index__].AgeAsOfDate" />
+                                                </div>
+                                            </div>
+
+                                            <button type="button" class="btn btn-outline-danger btn-sm removeHouseholdMemberBtn">
+                                                Remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                </template>
                             </div>
                         </div>
                     </div>
@@ -183,17 +457,20 @@
 
     <script>
         document.addEventListener("DOMContentLoaded", function () {
+            // Organization section
             const selectedOrganization = document.getElementById("selectedOrganization");
             const existingOrganizationCard = document.getElementById("existingOrganizationCard");
             const newOrganizationCard = document.getElementById("newOrganizationCard");
-            const toggleButton = document.getElementById("toggleNewOrganizationBtn");
+            const toggleOrganizationButton = document.getElementById("toggleNewOrganizationBtn");
             const newOrgInputs = document.querySelectorAll(".new-org-input");
-            const collapseElement = document.getElementById("newOrganizationCollapse");
-            const collapseInstance = bootstrap.Collapse.getOrCreateInstance(collapseElement, { toggle: false });
+            const organizationCollapseElement = document.getElementById("newOrganizationCollapse");
+            const organizationCollapseInstance = bootstrap.Collapse.getOrCreateInstance(organizationCollapseElement, { toggle: false });
 
             function hasNewOrganizationInput() {
                 for (const input of newOrgInputs) {
-                    if (input.value && input.value.trim() !== "") {
+                    if (input.type === "checkbox") {
+                        if (input.checked) return true;
+                    } else if (input.value && input.value.trim() !== "") {
                         return true;
                     }
                 }
@@ -202,37 +479,24 @@
 
             function setExistingOrganizationDisabled(isDisabled) {
                 selectedOrganization.disabled = isDisabled;
-
-                if (isDisabled) {
-                    existingOrganizationCard.classList.add("disabled-card");
-                } else {
-                    existingOrganizationCard.classList.remove("disabled-card");
-                }
+                existingOrganizationCard.classList.toggle("disabled-card", isDisabled);
             }
 
             function setNewOrganizationDisabled(isDisabled) {
+                newOrganizationCard.classList.toggle("disabled-card", isDisabled);
+                toggleOrganizationButton.disabled = isDisabled;
+
+                newOrgInputs.forEach(input => {
+                    input.disabled = isDisabled;
+                });
+
                 if (isDisabled) {
-                    newOrganizationCard.classList.add("disabled-card");
-                    toggleButton.disabled = true;
-
-                    newOrgInputs.forEach(input => {
-                        input.disabled = true;
-                    });
-
-                    collapseInstance.hide();
-                } else {
-                    newOrganizationCard.classList.remove("disabled-card");
-                    toggleButton.disabled = false;
-
-                    newOrgInputs.forEach(input => {
-                        input.disabled = false;
-                    });
+                    organizationCollapseInstance.hide();
                 }
             }
 
-            function updateWizardState() {
+            function updateOrganizationState() {
                 const hasExistingSelection = selectedOrganization.value !== "";
-                const hasNewInput = hasNewOrganizationInput();
 
                 if (hasExistingSelection) {
                     setNewOrganizationDisabled(true);
@@ -240,7 +504,7 @@
                     return;
                 }
 
-                if (hasNewInput) {
+                if (hasNewOrganizationInput()) {
                     setExistingOrganizationDisabled(true);
                     setNewOrganizationDisabled(false);
                     return;
@@ -250,14 +514,125 @@
                 setNewOrganizationDisabled(false);
             }
 
-            selectedOrganization.addEventListener("change", updateWizardState);
+            selectedOrganization.addEventListener("change", updateOrganizationState);
 
             newOrgInputs.forEach(input => {
-                input.addEventListener("input", updateWizardState);
-                input.addEventListener("change", updateWizardState);
+                input.addEventListener("input", updateOrganizationState);
+                input.addEventListener("change", updateOrganizationState);
             });
 
-            updateWizardState();
+            // Client section
+            const selectedClient = document.getElementById("selectedClient");
+            const existingClientCard = document.getElementById("existingClientCard");
+            const newClientCard = document.getElementById("newClientCard");
+            const toggleClientButton = document.getElementById("toggleNewClientBtn");
+            const clientCollapseElement = document.getElementById("newClientCollapse");
+            const clientCollapseInstance = bootstrap.Collapse.getOrCreateInstance(clientCollapseElement, { toggle: false });
+            const householdMembersContainer = document.getElementById("householdMembersContainer");
+            const householdTemplate = document.getElementById("householdMemberTemplate");
+            const addHouseholdMemberBtn = document.getElementById("addHouseholdMemberBtn");
+
+            function getNewClientInputs() {
+                return document.querySelectorAll(".new-client-input");
+            }
+
+            function hasNewClientInput() {
+                const inputs = getNewClientInputs();
+
+                for (const input of inputs) {
+                    if (input.type === "checkbox") {
+                        if (input.checked) return true;
+                    } else if (input.value && input.value.trim() !== "") {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            function setExistingClientDisabled(isDisabled) {
+                selectedClient.disabled = isDisabled;
+                existingClientCard.classList.toggle("disabled-card", isDisabled);
+            }
+
+            function setNewClientDisabled(isDisabled) {
+                newClientCard.classList.toggle("disabled-card", isDisabled);
+                toggleClientButton.disabled = isDisabled;
+                addHouseholdMemberBtn.disabled = isDisabled;
+
+                getNewClientInputs().forEach(input => {
+                    input.disabled = isDisabled;
+                });
+
+                document.querySelectorAll(".removeHouseholdMemberBtn").forEach(button => {
+                    button.disabled = isDisabled;
+                });
+
+                if (isDisabled) {
+                    clientCollapseInstance.hide();
+                }
+            }
+
+            function updateClientState() {
+                const hasExistingSelection = selectedClient.value !== "";
+
+                if (hasExistingSelection) {
+                    setNewClientDisabled(true);
+                    setExistingClientDisabled(false);
+                    return;
+                }
+
+                if (hasNewClientInput()) {
+                    setExistingClientDisabled(true);
+                    setNewClientDisabled(false);
+                    return;
+                }
+
+                setExistingClientDisabled(false);
+                setNewClientDisabled(false);
+            }
+
+            function rebindRemoveButtons() {
+                document.querySelectorAll(".removeHouseholdMemberBtn").forEach(button => {
+                    button.onclick = function () {
+                        const items = householdMembersContainer.querySelectorAll(".household-member-item");
+
+                        if (items.length > 1) {
+                            button.closest(".household-member-item").remove();
+                            updateClientState();
+                        } else {
+                            const parent = button.closest(".household-member-item");
+                            parent.querySelectorAll("input").forEach(input => input.value = "");
+                            updateClientState();
+                        }
+                    };
+                });
+            }
+
+            addHouseholdMemberBtn.addEventListener("click", function () {
+                const index = householdMembersContainer.querySelectorAll(".household-member-item").length;
+                const html = householdTemplate.innerHTML.replaceAll("__index__", index);
+                householdMembersContainer.insertAdjacentHTML("beforeend", html);
+                rebindRemoveButtons();
+                updateClientState();
+            });
+
+            selectedClient.addEventListener("change", updateClientState);
+
+            document.addEventListener("input", function (e) {
+                if (e.target.classList.contains("new-client-input")) {
+                    updateClientState();
+                }
+            });
+
+            document.addEventListener("change", function (e) {
+                if (e.target.classList.contains("new-client-input")) {
+                    updateClientState();
+                }
+            });
+
+            rebindRemoveButtons();
+            updateOrganizationState();
+            updateClientState();
         });
     </script>
 }

--- a/A New Hope/Views/Referrals/WizardStep2.cshtml
+++ b/A New Hope/Views/Referrals/WizardStep2.cshtml
@@ -1,0 +1,325 @@
+﻿@model A_New_Hope.Models.ViewModels.ReferralWizardStep1ViewModel
+
+@{
+    ViewData["Title"] = "New Referral - Step 2";
+}
+
+<div class="container py-4">
+    <h1 class="mb-2">New Referral</h1>
+    <p class="text-muted mb-4">Step 2 of 3: Review and confirm the referral details before saving.</p>
+
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="alert alert-danger">
+            @TempData["ErrorMessage"]
+        </div>
+    }
+
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+    <!-- Referring Organization -->
+    <div class="card shadow-sm wizard-card mb-4">
+        <div class="card-header bg-white">
+            <h4 class="mb-0">Referring Organization</h4>
+        </div>
+        <div class="card-body">
+            @if (Model.HasSelectedExistingOrganization)
+            {
+                <p class="mb-0">
+                    <strong>Existing Organization ID:</strong> @Model.SelectedReferringOrganizationId
+                </p>
+            }
+            else
+            {
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Organization Name:</strong><br />
+                        @Model.NewOrganizationName
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Primary Type of Service:</strong><br />
+                        @Model.NewOrganizationType
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Contact Person Name:</strong><br />
+                        @Model.NewPrimaryContactName
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Email Address:</strong><br />
+                        @Model.NewEmail
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Phone Number:</strong><br />
+                        @Model.NewPhoneNumber
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Address Line 1:</strong><br />
+                        @Model.NewAddressLine1
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Address Line 2:</strong><br />
+                        @Model.NewAddressLine2
+                    </div>
+                    <div class="col-md-4 mb-2">
+                        <strong>City:</strong><br />
+                        @Model.NewCity
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <strong>State:</strong><br />
+                        @Model.NewState
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4 mb-2">
+                        <strong>ZIP Code:</strong><br />
+                        @Model.NewPostalCode
+                    </div>
+                    <div class="col-md-8 mb-2">
+                        <strong>Notes:</strong><br />
+                        @(string.IsNullOrWhiteSpace(Model.NewNotes) ? "None" : Model.NewNotes)
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Client -->
+    <div class="card shadow-sm wizard-card mb-4">
+        <div class="card-header bg-white">
+            <h4 class="mb-0">Client</h4>
+        </div>
+        <div class="card-body">
+            @if (Model.HasSelectedExistingClient)
+            {
+                <p class="mb-0">
+                    <strong>Existing Client ID:</strong> @Model.SelectedClientUserId
+                </p>
+            }
+            else
+            {
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>First Name:</strong><br />
+                        @Model.NewClientFirstName
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Last Name:</strong><br />
+                        @Model.NewClientLastName
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Email Address:</strong><br />
+                        @Model.NewClientEmail
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Phone Number:</strong><br />
+                        @Model.NewClientPhoneNumber
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Date of Birth:</strong><br />
+                        @(Model.NewClientDateOfBirth?.ToString("yyyy-MM-dd") ?? "None")
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Address Line 1:</strong><br />
+                        @Model.NewClientAddressLine1
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Address Line 2:</strong><br />
+                        @Model.NewClientAddressLine2
+                    </div>
+                    <div class="col-md-4 mb-2">
+                        <strong>City:</strong><br />
+                        @Model.NewClientCity
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <strong>State:</strong><br />
+                        @Model.NewClientState
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>ZIP Code:</strong><br />
+                        @Model.NewClientPostalCode
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Client Profile -->
+    @if (!Model.HasSelectedExistingClient)
+    {
+        <div class="card shadow-sm wizard-card mb-4">
+            <div class="card-header bg-white">
+                <h4 class="mb-0">Client Profile</h4>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Employment Status:</strong><br />
+                        @(string.IsNullOrWhiteSpace(Model.NewClientEmploymentStatus) ? "None" : Model.NewClientEmploymentStatus)
+                    </div>
+                    <div class="col-md-6 mb-2">
+                        <strong>Monthly Earned Income:</strong><br />
+                        @(Model.NewClientEarnedIncomeMonthly.HasValue? Model.NewClientEarnedIncomeMonthly.Value.ToString("C") : "None")
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-2">
+                        <strong>Currently Unhoused:</strong><br />
+                        @(Model.NewClientIsUnhoused ? "Yes" : "No")
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
+    <!-- Household Members -->
+    @if (!Model.HasSelectedExistingClient)
+    {
+        <div class="card shadow-sm wizard-card mb-4">
+            <div class="card-header bg-white">
+                <h4 class="mb-0">Household Members</h4>
+            </div>
+            <div class="card-body">
+                @{
+                    var startedMembers = Model.HouseholdMembers?
+                    .Where(h => h.HasStarted)
+                    .ToList() ?? new List<A_New_Hope.Models.ViewModels.ReferralWizardHouseholdMemberViewModel>();
+                }
+
+                @if (startedMembers.Count == 0)
+                {
+                    <p class="mb-0 text-muted">No household members added.</p>
+                }
+                else
+                {
+                    @for (int i = 0; i < startedMembers.Count; i++)
+                    {
+                        var member = startedMembers[i];
+
+                        <div class="border rounded p-3 mb-3 bg-light">
+                            <h6 class="mb-3">Household Member @(i + 1)</h6>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-2">
+                                    <strong>First Name:</strong><br />
+                                    @member.FirstName
+                                </div>
+                                <div class="col-md-6 mb-2">
+                                    <strong>Last Name:</strong><br />
+                                    @member.LastName
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-2">
+                                    <strong>Date of Birth:</strong><br />
+                                    @(member.DateOfBirth?.ToString("yyyy-MM-dd") ?? "None")
+                                </div>
+                                <div class="col-md-6 mb-2">
+                                    <strong>Age As Of Date:</strong><br />
+                                    @(member.AgeAsOfDate?.ToString("yyyy-MM-dd") ?? "None")
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    }
+
+    <!-- Referral Details -->
+    <div class="card shadow-sm wizard-card mb-4">
+        <div class="card-header bg-white">
+            <h4 class="mb-0">Referral Details</h4>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-4 mb-2">
+                    <strong>Referral Date:</strong><br />
+                    @(Model.ReferredOn?.ToString("yyyy-MM-dd") ?? "None")
+                </div>
+                <div class="col-md-4 mb-2">
+                    <strong>Status:</strong><br />
+                    @(Model.Status?.ToString() ?? "None")
+                </div>
+                <div class="col-md-4 mb-2"></div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 mb-2">
+                    <strong>Valid From:</strong><br />
+                    @(Model.ValidFrom?.ToString("yyyy-MM-dd") ?? "None")
+                </div>
+                <div class="col-md-6 mb-2">
+                    <strong>Valid To:</strong><br />
+                    @(Model.ValidTo?.ToString("yyyy-MM-dd") ?? "None")
+                </div>
+            </div>
+
+            <hr />
+            <h5 class="mb-3">Referrer Contact</h5>
+
+            <div class="row">
+                <div class="col-md-4 mb-2">
+                    <strong>Referrer Name:</strong><br />
+                    @(string.IsNullOrWhiteSpace(Model.ReferredByName) ? "None" : Model.ReferredByName)
+                </div>
+                <div class="col-md-4 mb-2">
+                    <strong>Referrer Phone Number:</strong><br />
+                    @(string.IsNullOrWhiteSpace(Model.ReferredByPhoneNumber) ? "None" : Model.ReferredByPhoneNumber)
+                </div>
+                <div class="col-md-4 mb-2">
+                    <strong>Referrer Email:</strong><br />
+                    @(string.IsNullOrWhiteSpace(Model.ReferredByEmail) ? "None" : Model.ReferredByEmail)
+                </div>
+            </div>
+
+            <div class="mb-2">
+                <strong>Notes:</strong><br />
+                @(string.IsNullOrWhiteSpace(Model.ReferralNotes) ? "None" : Model.ReferralNotes)
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex justify-content-end gap-2 mt-4">
+        <a asp-action="WizardStep1" class="btn btn-outline-secondary">Back</a>
+
+        <form asp-action="WizardStep2Confirm" method="post" class="d-inline">
+            @Html.AntiForgeryToken()
+            <button type="submit" class="btn btn-primary">Confirm Referral</button>
+        </form>
+    </div>
+</div>
+
+<style>
+    .wizard-card {
+        border-radius: 12px;
+        border: 1px solid #d9dee3;
+    }
+
+        .wizard-card .card-header {
+            border-bottom: 1px solid #e9ecef;
+        }
+</style>


### PR DESCRIPTION
White010/#64 referral/referring organization/client workflow

- Controllers/ReferralsController.cs - Updated to add WizardStep1 GET/POST actions, support selecting an existing referring organization or creating a new one inline, and include normalization/validation logic for the wizard’s Step 1 fields.
- Models/ViewModels/ReferralWizardStep1ViewModel.cs - Added as a new view model to hold Step 1 wizard data for both existing-organization selection and full new-organization entry fields.
- Views/Referrals/WizardStep1.cshtml - Added/updated to create the Step 1 wizard UI with stacked cards, an OR divider, expandable new-organization entry fields, and client-side behavior that disables one path when the other is being used.
- Views/Home/Index.cshtml- Updated to replace the old client list/search landing page with a workflow launcher page showing three horizontal wizard cards, including the link to start the Referral Wizard.
- Fixed an issue with a type mismatch with DB DateOnly vs. DateTime rendering in the DateOfBirth field for DomainUser.cs. Updated ApplicateDbContext.cs to perform a conversion.
- Models/ViewModels/ReferralWizardStep1ViewModel.cs - Expanded the Step 1 view model to support both existing/new Referring Organization selection, existing/new Client selection, static ClientProfile entry for new clients, and an optional one-to-many HouseholdMembers collection.
- Models/ViewModels/ReferralWizardHouseholdMemberViewModel.cs - Added a new household-member entry view model to support repeatable household rows in the Step 1 wizard with per-row fields and “has started” detection.
- Controllers/ReferralsController.cs - Updated the Step 1 wizard GET/POST flow to initialize household rows, normalize and validate organization/client/profile/household input, and create related ReferringOrganization, DomainUser, ClientProfile, and HouseholdMember records when needed.
- Views/Referrals/WizardStep1.cshtml - Updated the Step 1 wizard UI to add the new Client section enhancements, including static ClientProfile fields, optional repeatable HouseholdMember entry rows, and client-side mutual-exclusion behavior between existing-client and new-client paths.
- Updated the Referral Wizard bootstrap collapsing cards to keep Household Member card initial collapsed when Add Client is expanded.
- Fixed an issue in the Referral Wizard cshtml where the user could not add more than one household member, nor delete the household member card if it was added in error.
- Models/ViewModels/ReferralWizardStep1ViewModel.cs - Expanded the referral Step 1 view model to hold the data needed by the referrals card workflow.
- Models/ViewModels/ReferralWizardHouseholdMemberViewModel.cs - Added support for repeatable household member entries within the referral workflow.
- Views/Referrals/WizardStep1.cshtml - Updated the referral Step 1 card UI to collect organization, client, profile, and household information.
- Refactor of the Organization and Client/Profile/Household Members cards in the Referral Wizard.
- Program.cs - Updated the app startup to enable Session so the referral wizard draft can persist between Step 1 and Step 2.
- Controllers/ReferralsController.cs - Refactored the wizard so Step 1 stores the full draft in Session and Step 2 confirmation creates all records in one final transaction.
- Views/Referrals/WizardStep2.cshtml - Added a read-only confirmation page that reviews the full referral draft and submits the final confirm action.